### PR TITLE
Check for old configs

### DIFF
--- a/src/riak_api_pb_listener.erl
+++ b/src/riak_api_pb_listener.erl
@@ -24,7 +24,7 @@
 
 -module(riak_api_pb_listener).
 -behaviour(gen_nb_server).
--export([start_link/0]).
+-export([start_link/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 -export([sock_opts/0, new_connection/2]).
@@ -32,10 +32,8 @@
 -record(state, {portnum}).
 
 %% @doc Starts the PB listener
--spec start_link() -> {ok, pid()} | {error, term()}.
-start_link() ->
-    PortNum = get_port(),
-    IpAddr = get_ip(),
+-spec start_link(inet:ip_address() | string(),  non_neg_integer()) -> {ok, pid()} | {error, term()}.
+start_link(IpAddr, PortNum) ->
     gen_nb_server:start_link(?MODULE, IpAddr, PortNum, [PortNum]).
 
 %% @doc Initialization callback for gen_nb_server.

--- a/src/riak_api_pb_listener.erl
+++ b/src/riak_api_pb_listener.erl
@@ -28,6 +28,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 -export([sock_opts/0, new_connection/2]).
+-export([get_port/0, get_ip/0]).
 -record(state, {portnum}).
 
 %% @doc Starts the PB listener
@@ -102,7 +103,9 @@ get_port() ->
                           " riak_api/pb_port in the future."),
             Port;
         {default, undefined} ->
-            throw({error, "pb_port config not defined"})
+            lager:warning("The config riak_api/pb_port is missing,"
+                          " PB connections will be disabled."),
+            undefined
     end.
 
 %% @private
@@ -118,5 +121,7 @@ get_ip() ->
                           " riak_api/pb_ip in the future."),
             IP;
         {default, undefined} ->
-            throw({error, "pb_ip config not defined"})
+            lager:warning("The config riak_api/pb_ip is missing,"
+                          " PB connections will be disabled."),
+            undefined
     end.

--- a/src/riak_api_sup.erl
+++ b/src/riak_api_sup.erl
@@ -30,7 +30,7 @@
          init/1]).
 
 -define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
-
+-define(CHILD(I, Type, Args), {I, {I, start_link, Args}, permanent, 5000, Type, [I]}).
 
 %% @doc Starts the supervisor.
 -spec start_link() -> {ok, pid()} | {error, term()}.
@@ -44,11 +44,12 @@ start_link() ->
       MaxT :: pos_integer(),
       ChildSpec :: supervisor:child_spec().
 init([]) ->
-    IsPbConfigured = (riak_api_pb_listener:get_port() /= undefined)
-                      andalso (riak_api_pb_listener:get_ip() /= undefined),
+    Port = riak_api_pb_listener:get_port(),
+    IP = riak_api_pb_listener:get_ip(),
+    IsPbConfigured = (Port /= undefined) andalso (IP /= undefined),
     Processes = if IsPbConfigured ->
                         [?CHILD(riak_api_pb_sup, supervisor),
-                         ?CHILD(riak_api_pb_listener, worker)];
+                         ?CHILD(riak_api_pb_listener, worker, [IP, Port])];
                    true ->
                         []
                 end,


### PR DESCRIPTION
Since users will more than likely not immediately update their app
configs before restarting Riak after an upgrade then Riak API needs to
check for the old configs.  If the old config is found then that value
will be used and a warning will be logged.

This relies on basho/riak_core#182
