### PR TITLE
Late registration

### DIFF
--- a/src/riak_api.app.src
+++ b/src/riak_api.app.src
@@ -7,7 +7,6 @@
   {applications, [
                   kernel,
                   stdlib,
-                  sasl,
                   lager
                  ]},
   {registered, [riak_api_sup,

--- a/src/riak_api.app.src
+++ b/src/riak_api.app.src
@@ -7,7 +7,8 @@
   {applications, [
                   kernel,
                   stdlib,
-                  sasl
+                  sasl,
+                  lager
                  ]},
   {registered, [riak_api_sup,
                 riak_api_pb_sup]},

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -83,21 +83,21 @@ handle_call({set_socket, Socket}, _From, State) ->
 
 %% @doc The handle_cast/2 gen_server callback.
 -spec handle_cast(Message::term(), State::#state{}) -> {noreply, NewState::#state{}}.
-handle_cast({registered, Module}, #state{states=ServiceStates}=State) ->
+handle_cast({registered, Service}, #state{states=ServiceStates}=State) ->
     %% When a new service is registered after a client connection is
     %% already established, update the internal state to support the
     %% new capabilities.
-    NewStates = case dict:find(Module, ServiceStates) of
-                    error ->
-                        %% This is a new service registering
-                        dict:store(Module, Module:init(), ServiceStates);
-                    {ok, Module} ->
-                        %% This is an existing service registering
-                        %% disjoint message codes
-                        ServiceStates
-                end,
-    {noreply, State#state{dispatch=riak_api_pb_service:dispatch_table(),
-                          states=NewStates}};
+    NewDispatch = riak_api_pb_service:dispatch_table(),
+    case dict:is_key(Service, ServiceStates) of
+        true ->
+            %% This is an existing service registering
+            %% disjoint message codes
+            {noreply, State#state{dispatch=NewDispatch}};
+        false ->
+            %% This is a new service registering
+            {noreply, State#state{dispatch=NewDispatch,
+                                  states=dict:store(Service, Service:init(), ServiceStates)}}
+    end;
 handle_cast(_Msg, State) ->
     {noreply, State}.
 

--- a/src/riak_api_pb_service.erl
+++ b/src/riak_api_pb_service.erl
@@ -101,6 +101,7 @@ register(Module, MinCode, MaxCode) ->
                                           dict:store(I, Module, D)
                                   end, Registrations, CodeRange),
             application:set_env(riak_api, services, NewRegs),
+            riak_api_pb_sup:service_registered(Module),
             ok;
         AlreadyClaimed ->
             {error, {already_registered, AlreadyClaimed}}

--- a/test/pb_service_test.erl
+++ b/test/pb_service_test.erl
@@ -26,6 +26,8 @@ decode(106, <<>>) ->
     {ok, internalerror};
 decode(107, <<>>) ->
     {ok, stream};
+decode(110, _) ->
+    {ok, dummyreq};
 decode(_,_) ->
     {error, unknown_message}.
 
@@ -91,10 +93,10 @@ cleanup({S, H, P}) ->
     ok.
 
 request(Code, Payload) when is_binary(Payload), is_integer(Code) ->
-    Host = app_helper:get_env(riak_api, pb_ip),
-    Port = app_helper:get_env(riak_api, pb_port),
-    {ok, Socket} = gen_tcp:connect(Host, Port, [binary, {active, false}, {packet,4},
-                                                {header, 1}, {nodelay, true}]),
+    {ok, Socket} = new_connection(),
+    request(Code, Payload, Socket).
+
+request(Code, Payload, Socket) when is_binary(Payload), is_integer(Code) ->
     ok = gen_tcp:send(Socket, <<Code:8, Payload/binary>>),
     {ok, Response} = gen_tcp:recv(Socket, 0),
     Response.
@@ -102,10 +104,7 @@ request(Code, Payload) when is_binary(Payload), is_integer(Code) ->
 request_stream(Code, Payload, DonePredicate) when is_binary(Payload),
                                                   is_integer(Code),
                                                   is_function(DonePredicate) ->
-    Host = app_helper:get_env(riak_api, pb_ip),
-    Port = app_helper:get_env(riak_api, pb_port),
-    {ok, Socket} = gen_tcp:connect(Host, Port, [binary, {active, false}, {packet,4},
-                                                {header, 1}, {nodelay, true}]),
+    {ok, Socket} = new_connection(),
     ok = gen_tcp:send(Socket, <<Code:8, Payload/binary>>),
     stream_loop([], gen_tcp:recv(Socket, 0), Socket, DonePredicate).
 
@@ -118,6 +117,11 @@ stream_loop(Acc0, {ok, [Code|Bin]=Packet}, Socket, Predicate) ->
             stream_loop(Acc, gen_tcp:recv(Socket, 0), Socket, Predicate)
     end.
 
+new_connection() ->
+    Host = app_helper:get_env(riak_api, pb_ip),
+    Port = app_helper:get_env(riak_api, pb_port),
+    gen_tcp:connect(Host, Port, [binary, {active, false}, {packet,4},
+                                 {header, 1}, {nodelay, true}]).
 
 simple_test_() ->
     {setup,
@@ -138,3 +142,21 @@ simple_test_() ->
       %% Internal service error
       ?_assertMatch([0|Bin] when is_binary(Bin), request(106, <<>>))
      ]}.
+
+late_registration_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     ?_test(begin
+                %% First we check that the unregistered message code
+                %% returns an error to the client.
+                ?assertMatch([0|Bin] when is_binary(Bin), request(110, <<>>)),
+                %% Now we make a new connection
+                {ok, Socket} = new_connection(),
+                %% And with the connection open, register the message code late.
+                riak_api_pb_service:register(?MODULE, 110),
+                %% Now request the message and we should get success.
+                ?assertEqual([102|<<"ok">>], request(110, <<>>, Socket))
+            end)
+    }.
+


### PR DESCRIPTION
Allow services that are registered after `riak_api` is started to get initialized on existing client connections.  Since `reltool` doesn't guarantee any start order for applications in the rel (aside from declared dependencies), we need a way to "upgrade" existing connections that may have been established while an app that registers services is starting up.

This also fixes a dependency on lager in the `.app` file.
