### PR TITLE
Add PB connection stats to riak_api

### DIFF
--- a/src/riak_api_app.erl
+++ b/src/riak_api_app.erl
@@ -53,6 +53,8 @@ start(_Type, _StartArgs) ->
             %% and then propagate config information for client
             %% auto-config.
             %% riak_core:register(riak_api, []),
+            %% register stats
+            riak_api_stat:register_stats(),
             {ok, Pid};
         {error, Reason} ->
             {error, Reason}

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -65,8 +65,7 @@ set_socket(Pid, Socket) ->
 %% riak_api_pb_server.
 -spec init(list()) -> {ok, #state{}}.
 init([]) ->
-    %% TODO: use Russell's new stats system
-    %% riak_kv_stat:update(pbc_connect)
+    riak_api_stat:update(pbc_connect),
     Dispatch = riak_api_pb_service:dispatch_table(),
     ServiceStates = lists:foldl(fun(Service, States) ->
                                         dict:store(Service, Service:init(), States)
@@ -178,8 +177,7 @@ handle_info(Message, State) ->
       Reason :: normal | shutdown | {shutdown,term()} | term(),
       State :: #state{}.
 terminate(_Reason, _State) ->
-    %% TODO: Update with Russell's new stats system
-    %% riak_kv_stat:update(pbc_disconnect),
+    riak_api_stat:update(pbc_disconnect),
     ok.
 
 %% @doc The gen_server code_change/3 callback, called when performing

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -1,0 +1,111 @@
+%% -------------------------------------------------------------------
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%%
+%% @doc Collector for various api stats.
+-module(riak_api_stat).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link /0, register_stats/0,
+         get_stats/0,
+         produce_stats/0,
+         update/1,
+         stats/0]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+-define(APP, riak_api).
+
+%% -------------------------------------------------------------------
+%% API
+%% -------------------------------------------------------------------
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+register_stats() ->
+    [register_stat(Stat, Type) || {Stat, Type} <- stats()],
+    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
+
+%% @doc Return current aggregation of all stats.
+-spec get_stats() -> proplists:proplist().
+get_stats() ->
+    case riak_core_stat_cache:get_stats(?APP) of
+        {ok, Stats, _TS} ->
+            Stats;
+        Error -> Error
+    end.
+
+produce_stats() ->
+    {?APP, [{Name, get_metric_value({?APP, Name}, Type)} || {Name, Type} <- stats()]}.
+
+update(Arg) ->
+    gen_server:cast(?SERVER, {update, Arg}).
+
+%% gen_server
+
+init([]) ->
+    {ok, ok}.
+
+handle_call(_Req, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast({update, Arg}, State) ->
+    update1(Arg),
+    {noreply, State};
+handle_cast(_Req, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% @doc Update the given `Stat'.
+-spec update1(term()) -> ok.
+update1(pbc_connect) ->
+    folsom_metrics:notify_existing_metric({?APP, pbc_connects_active}, {inc, 1}, counter),
+    folsom_metrics:notify_existing_metric({?APP, pbc_connects}, 1, spiral);
+update1(pbc_disconnect) ->
+    folsom_metrics:notify_existing_metric({?APP, pbc_connects_active}, {dec, 1}, counter).
+
+%% -------------------------------------------------------------------
+%% Private
+%% -------------------------------------------------------------------
+get_metric_value(Name, _Type) ->
+    folsom_metrics:get_metric_value(Name).
+
+stats() ->
+    [
+     {pbc_connects, spiral},
+     {pbc_connects_active, counter}
+    ].
+
+register_stat(Name, spiral) ->
+    folsom_metrics:new_spiral({?APP, Name});
+register_stat(Name, counter) ->
+    folsom_metrics:new_counter({?APP, Name}).

--- a/src/riak_api_sup.erl
+++ b/src/riak_api_sup.erl
@@ -49,7 +49,8 @@ init([]) ->
     IsPbConfigured = (Port /= undefined) andalso (IP /= undefined),
     Processes = if IsPbConfigured ->
                         [?CHILD(riak_api_pb_sup, supervisor),
-                         ?CHILD(riak_api_pb_listener, worker, [IP, Port])];
+                         ?CHILD(riak_api_pb_listener, worker, [IP, Port]),
+                         ?CHILD(riak_api_stat, worker)];
                    true ->
                         []
                 end,

--- a/test/pb_service_test.erl
+++ b/test/pb_service_test.erl
@@ -82,6 +82,10 @@ setup() ->
     application:set_env(lager, error_logger_redirect, true),
     ok = application:start(lager),
 
+    %% start the stat cache
+    ok = application:start(folsom),
+    riak_core_stat_cache:start_link(),
+
     OldServices = riak_api_pb_service:dispatch_table(),
     OldHost = app_helper:get_env(riak_api, pb_ip, "127.0.0.1"),
     OldPort = app_helper:get_env(riak_api, pb_port, 8087),
@@ -89,7 +93,6 @@ setup() ->
     application:set_env(riak_api, pb_ip, "127.0.0.1"),
     application:set_env(riak_api, pb_port, 32767),
     riak_api_pb_service:register(?MODULE, ?MSGMIN, ?MSGMAX),
-
     ok = application:start(riak_api),
     {OldServices, OldHost, OldPort}.
 
@@ -98,6 +101,8 @@ cleanup({S, H, P}) ->
     application:set_env(riak_api, services, S),
     application:set_env(riak_api, pb_ip, H),
     application:set_env(riak_api, pb_port, P),
+    application:stop(folsom),
+    riak_core_stat_cache:stop(),
     application:stop(lager),
     ok.
 


### PR DESCRIPTION
The PB connection stats used to be in riak_kv. riak_pb does not depend on riak_kv so it was not calling riak_kv_stat:update/1 for pb connect stats.

This PR fills out those `TODO`s in the code for stats by adding a gen_server for stats that registers stats with folsom, and produces stats on requests. Uses the same pattern as the other riak_\* apps. Uses the core stat cache server.
