### PR TITLE
Add riak_core as application dep to riak_api.app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: erlang
+script: (rebar compile && rebar eunit skip_deps=true) || (find . -name "*.log" -print -exec cat \{\} \; && sh -c "exit 1")
 notifications:
   webhooks: http://basho-engbot.herokuapp.com/travis?key=99ba84bc061813790957ee348953cfb45e413900
   email: eng@basho.com

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 {cover_enabled, true}.
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
+{eunit_opts, [verbose]}.
 {deps, [
         {lager, ".*", {git, "git://github.com/basho/lager.git", "master"}},
         {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", "master"}},

--- a/src/riak_api.app.src
+++ b/src/riak_api.app.src
@@ -7,7 +7,8 @@
   {applications, [
                   kernel,
                   stdlib,
-                  lager
+                  lager,
+                  riak_core
                  ]},
   {registered, [riak_api_sup,
                 riak_api_pb_sup]},

--- a/test/pb_service_test.erl
+++ b/test/pb_service_test.erl
@@ -86,7 +86,6 @@ setup() ->
     riak_api_pb_service:register(?MODULE, ?MSGMIN, ?MSGMAX),
 
     [ application:start(A) || A <- Deps ],
-    riak_core:wait_for_application(riak_api),
     {OldServices, OldHost, OldPort, Deps}.
 
 cleanup({S, H, P, Deps}) ->

--- a/test/pb_service_test.erl
+++ b/test/pb_service_test.erl
@@ -77,6 +77,8 @@ setup() ->
     application:set_env(lager, handlers, [{lager_file_backend, [{"pb_service_test.log", debug, 10485760, "$D0", 5}]}]),
     application:set_env(lager, error_logger_redirect, true),
 
+    application:set_env(riak_core, handoff_port, 0),
+
     OldServices = riak_api_pb_service:dispatch_table(),
     OldHost = app_helper:get_env(riak_api, pb_ip, "127.0.0.1"),
     OldPort = app_helper:get_env(riak_api, pb_port, 8087),
@@ -214,7 +216,7 @@ dep_apps(App) ->
     Apps.
 
 all_deps(App) ->
-    [ all_deps(Dep) || Dep <- dep_apps(App) ] ++ [App].
+    [[ all_deps(Dep) || Dep <- dep_apps(App) ],App].
 
 resolve_deps(App) ->
     DepList = lists:flatten(all_deps(App)),


### PR DESCRIPTION
When generating a release with erlang r14b0\* riak fails to start with:

```
{"Kernel pid terminated",application_controller,
    "{application_start_failure,riak_api,{bad_return, {{riak_api_app,start,[normal,[]]},
        {'EXIT',{noproc,{gen_server,call,
           [riak_core_stat_cache,{register,riak_api,{riak_api_stat,produce_stats,[]},5}]}}}}}}"}
```

This is due to the start order in the generated `riak.script`.
According to systools' man page -

> "The applications are sorted according to the dependencies between
> the applications. Where there are no dependencies, the order in the
> .rel file is kept."

There may be a better way to control the
order in the `rel` file, but this PR fixes the issue by
declaring riak_api's dependency on riak_core.
