### PR TITLE
Register riak_api_stat mod with riak_core at start up

### DIFF
--- a/src/riak_api_app.erl
+++ b/src/riak_api_app.erl
@@ -54,7 +54,7 @@ start(_Type, _StartArgs) ->
             %% auto-config.
             %% riak_core:register(riak_api, []),
             %% register stats
-            riak_api_stat:register_stats(),
+            riak_core:register(riak_api, [{stat_mod, riak_api_stat}]),
             {ok, Pid};
         {error, Reason} ->
             {error, Reason}

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -44,6 +44,7 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
+    [(catch folsom_metrics:delete_metric({?APP, Name})) || {Name, _Type} <- stats()],
     [register_stat(Stat, Type) || {Stat, Type} <- stats()],
     riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
 


### PR DESCRIPTION
Delete all stats at register time to ensure folsom is
consistent.
