### PR TITLE
Let riak_core supervise riak_api_stat

### DIFF
--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -66,6 +66,7 @@ update(Arg) ->
 %% gen_server
 
 init([]) ->
+    register_stats(),
     {ok, ok}.
 
 handle_call(_Req, _From, State) ->

--- a/src/riak_api_sup.erl
+++ b/src/riak_api_sup.erl
@@ -49,8 +49,7 @@ init([]) ->
     IsPbConfigured = (Port /= undefined) andalso (IP /= undefined),
     Processes = if IsPbConfigured ->
                         [?CHILD(riak_api_pb_sup, supervisor),
-                         ?CHILD(riak_api_pb_listener, worker, [IP, Port]),
-                         ?CHILD(riak_api_stat, worker)];
+                         ?CHILD(riak_api_pb_listener, worker, [IP, Port])];
                    true ->
                         []
                 end,


### PR DESCRIPTION
Register stats with folsom on start of gen_server, this ensures
folsom consistency in the face of a crash.
