### PR TITLE
Add deregistration of services

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 {cover_enabled, true}.
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
+{eunit_opts, [verbose]}.
 {deps, [
         {lager, ".*", {git, "git://github.com/basho/lager.git", "master"}},
         {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", "master"}},

--- a/src/riak_api_app.erl
+++ b/src/riak_api_app.erl
@@ -27,6 +27,9 @@
 -export([start/2,
          stop/1]).
 
+-define(SERVICES, [{riak_api_basic_pb_service, 1, 2},
+                   {riak_api_basic_pb_service, 7, 8}]).
+
 %% @doc The application:start callback.
 -spec start(Type, StartArgs)
            -> {ok, Pid} | {ok, Pid, State} | {error, Reason} when
@@ -43,8 +46,7 @@ start(_Type, _StartArgs) ->
     %% TODO: cluster_info registration. What do we expose?
     %% catch cluster_info:register_app(riak_api_cinfo),
 
-    ok = riak_api_pb_service:register(riak_api_basic_pb_service, 1, 2),
-    ok = riak_api_pb_service:register(riak_api_basic_pb_service, 7, 8),
+    ok = riak_api_pb_service:register(?SERVICES),
 
     case riak_api_sup:start_link() of
         {ok, Pid} ->
@@ -63,4 +65,5 @@ start(_Type, _StartArgs) ->
 %% @doc The application:stop callback.
 -spec stop(State::term()) -> ok.
 stop(_State) ->
+    ok = riak_api_pb_service:deregister(?SERVICES),
     ok.

--- a/src/riak_api_app.erl
+++ b/src/riak_api_app.erl
@@ -43,20 +43,9 @@
 start(_Type, _StartArgs) ->
     riak_core_util:start_app_deps(riak_api),
 
-    %% TODO: cluster_info registration. What do we expose?
-    %% catch cluster_info:register_app(riak_api_cinfo),
-
-    ok = riak_api_pb_service:register(?SERVICES),
-
     case riak_api_sup:start_link() of
         {ok, Pid} ->
-            %% TODO: Is it necessary to register the service? We might
-            %% want to use the registration to cause service_up events
-            %% and then propagate config information for client
-            %% auto-config.
-            %% riak_core:register(riak_api, []),
-            %% register stats
-            riak_core:register(riak_api, [{stat_mod, riak_api_stat}]),
+            ok = riak_api_pb_service:register(?SERVICES),
             {ok, Pid};
         {error, Reason} ->
             {error, Reason}

--- a/src/riak_api_pb_registrar.erl
+++ b/src/riak_api_pb_registrar.erl
@@ -1,0 +1,246 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_api_pb_registrar: Riak Client APIs Protocol Buffers Service Registration
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Encapsulates the Protocol Buffers service registration and
+%% deregistration as a gen_server process. This is used to serialize
+%% write access to the registration table so that it is less prone to
+%% race-conditions.
+
+-module(riak_api_pb_registrar).
+
+-behaviour(gen_server).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-compile([export_all]).
+-endif.
+
+-define(SERVER, ?MODULE).
+
+%% External exports
+-export([
+         start_link/0,
+         register/1,
+         deregister/1
+        ]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+
+-import(riak_api_pb_service, [services/0, dispatch_table/0]).
+
+%%--------------------------------------------------------------------
+%%% Public API
+%%--------------------------------------------------------------------
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+-spec register([riak_api_pb_service:registration()]) -> ok | {error, Reason::term()}.
+register(Registrations) ->
+    gen_server:call(?SERVER, {register, Registrations}, infinity).
+
+-spec deregister([riak_api_pb_service:registration()]) -> ok | {error, Reason::term()}.
+deregister(Registrations) ->
+    gen_server:call(?SERVER, {deregister, Registrations}, infinity).
+
+%%--------------------------------------------------------------------
+%%% gen_server callbacks
+%%--------------------------------------------------------------------
+init([]) ->
+    {ok, undefined}.
+
+handle_call({register, Registrations}, _From, State) ->
+    Reply = do_register(Registrations),
+    {reply, Reply, State};
+handle_call({deregister, Registrations}, _From, State) ->
+    Reply = do_deregister(Registrations),
+    {reply, Reply, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+%%% Internal functions
+%%--------------------------------------------------------------------
+
+do_register([]) ->
+    ok;
+do_register([{Module, MinCode, MaxCode}|Rest]) ->
+    case do_register(Module, MinCode, MaxCode) of
+        ok ->
+            do_register(Rest);
+        Error ->
+            Error
+    end.
+
+do_register(_Module, MinCode, MaxCode) when MinCode > MaxCode orelse
+MinCode < 1 orelse
+MaxCode < 1 ->
+    {error, invalid_message_code_range};
+do_register(Module, MinCode, MaxCode) ->
+    Registrations = dispatch_table(),
+    IsRegistered = fun(I) -> dict:is_key(I, Registrations) end,
+    CodeRange = lists:seq(MinCode, MaxCode),
+    case lists:filter(IsRegistered, CodeRange) of
+        [] ->
+            NewRegs = lists:foldl(fun(I, D) ->
+                                          dict:store(I, Module, D)
+                                  end, Registrations, CodeRange),
+            application:set_env(riak_api, services, NewRegs),
+            riak_api_pb_sup:service_registered(Module),
+            ok;
+        AlreadyClaimed ->
+            {error, {already_registered, AlreadyClaimed}}
+    end.
+
+
+do_deregister([]) ->
+    ok;
+do_deregister([{Module, MinCode, MaxCode}|Rest]) ->
+    case do_deregister(Module, MinCode, MaxCode) of
+        ok ->
+            do_deregister(Rest);
+        Other ->
+            Other
+    end.
+
+do_deregister(_Module, MinCode, MaxCode) when MinCode > MaxCode orelse
+MinCode < 1 orelse
+MaxCode < 1 ->
+    {error, invalid_message_code_range};
+do_deregister(Module, MinCode, MaxCode) ->
+    Registrations = dispatch_table(),
+    CodeRange = lists:seq(MinCode, MaxCode),
+    %% Figure out whether all of the codes can be deregistered.
+    Mapper = fun(I) ->
+                     case dict:find(I, Registrations) of
+                         error ->
+                             {error, {unregistered, I}};
+                         {ok, Module} ->
+                             I;
+                         {ok, _OtherModule} ->
+                             {error, {not_owned, I}}
+                     end
+             end,
+    ToRemove = [ Mapper(I) || I <- CodeRange ],
+    case ToRemove of
+        CodeRange ->
+            %% All codes are valid, so remove them, set the env and
+            %% notify active server processes.
+            NewRegs = lists:foldl(fun dict:erase/2, Registrations, CodeRange),
+            application:set_env(riak_api, services, NewRegs),
+            riak_api_pb_sup:service_registered(Module),
+            ok;
+        _ ->
+            %% There was at least one error, return it.
+            lists:keyfind(error, 1, ToRemove)
+    end.
+
+
+
+-ifdef(TEST).
+
+test_start() ->
+    gen_server:start({local, ?SERVER}, ?MODULE, [], []).
+
+setup() ->
+    OldServices = app_helper:get_env(riak_api, services, dict:new()),
+    application:set_env(riak_api, services, dict:new()),
+    {ok, Pid} = test_start(),
+    {Pid, OldServices}.
+
+cleanup({Pid, Services}) ->
+    exit(Pid, kill),
+    application:set_env(riak_api, services, Services).
+
+deregister_test_() ->
+    {foreach,
+     fun setup/0,
+     fun cleanup/1,
+     [
+      %% Deregister a previously registered service
+      ?_assertEqual(ok, begin
+                            ok = riak_api_pb_service:register(foo, 1, 2),
+                            riak_api_pb_service:deregister(foo, 1, 2)
+                        end),
+      %% Invalid deregistration: range is invalid
+      ?_assertEqual({error, invalid_message_code_range}, riak_api_pb_service:deregister(foo, 2, 1)),
+      %% Invalid deregistration: unregistered range
+      ?_assertEqual({error, {unregistered, 1}}, riak_api_pb_service:deregister(foo, 1, 1)),
+      %% Invalid deregistration: registered to other service
+      ?_assertEqual({error, {not_owned, 1}}, begin
+                                                 ok = riak_api_pb_service:register(foo, 1, 2),
+                                                 riak_api_pb_service:deregister(bar, 1)
+                                             end),
+      %% Deregister multiple
+      ?_assertEqual(ok, begin
+                            ok = register([{foo, 1, 2}, {bar, 3, 4}]),
+                            deregister([{bar, 3, 4}, {foo, 1, 2}])
+                        end)
+     ]}.
+
+register_test_() ->
+    {foreach,
+     fun setup/0,
+     fun cleanup/1,
+     [
+      %% Valid registration range
+      ?_assertEqual(foo, begin
+                             ok = riak_api_pb_service:register(foo,1,2),
+                             dict:fetch(1, dispatch_table())
+                         end),
+      %% Registration ranges that are invalid
+      ?_assertEqual({error, invalid_message_code_range},
+                    riak_api_pb_service:register(foo, 2, 1)),
+      ?_assertEqual({error, {already_registered, [1, 2]}},
+                    begin
+                        ok = riak_api_pb_service:register(foo, 1, 2),
+                        riak_api_pb_service:register(bar, 1, 3)
+                    end),
+      %% Register multiple
+      ?_assertEqual(ok, register([{foo, 1, 2}, {bar, 3, 4}]))
+     ]}.
+
+services_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     [
+      ?_assertEqual([], services()),
+      ?_assertEqual([bar, foo], begin
+                                    riak_api_pb_service:register(foo, 1, 2),
+                                    riak_api_pb_service:register(bar, 3, 4),
+                                    services()
+                                end)
+     ]}.
+
+-endif.

--- a/src/riak_api_pb_service.erl
+++ b/src/riak_api_pb_service.erl
@@ -31,11 +31,7 @@
 %% @end
 
 -module(riak_api_pb_service).
-
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
--compile([export_all, {no_auto_import, [register/2]}]).
--endif.
+-compile([{no_auto_import, [register/2]}]).
 
 %% Behaviour API
 -export([behaviour_info/1]).
@@ -52,6 +48,10 @@
 -export([dispatch_table/0,
          services/0]).
 
+-type registration() :: {Service::module(), MinCode::pos_integer(), MaxCode::pos_integer()}.
+
+-export_type([registration/0]).
+
 %% @doc Behaviour information callback. PB API services must implement
 %% the given functions.
 behaviour_info(callbacks) ->
@@ -65,24 +65,18 @@ behaviour_info(_) ->
 
 %% @doc Registers a number of services at once.
 %% @see register/3
--type registration() :: {Service::module(), MinCode::pos_integer(), MaxCode::pos_integer()}.
 -spec register([registration()]) -> ok | {error, Reason::term()}.
 register([]) ->
     ok;
-register([{Module, MinCode, MaxCode}|Rest]) ->
-    case register(Module, MinCode, MaxCode) of
-        ok ->
-            register(Rest);
-        Other ->
-            Other
-    end.
+register(List) ->
+    riak_api_pb_registrar:register(List).
 
 %% @doc Registers a service module for a given message code.
 %% @equiv register(Module, Code, Code)
 %% @see register/3
 -spec register(Module::module(), Code::pos_integer()) -> ok | {error, Err::term()}.
 register(Module, Code) ->
-    register(Module, Code, Code).
+    register([{Module, Code, Code}]).
 
 %% @doc Registers a service module for a given range of message
 %% codes. The service module must implement the behaviour and be able
@@ -90,25 +84,8 @@ register(Module, Code) ->
 %% codes.  Service modules should be registered before the riak_api
 %% application starts.
 -spec register(Module::module(), MinCode::pos_integer(), MaxCode::pos_integer()) -> ok | {error, Err::term()}.
-register(_Module, MinCode, MaxCode) when MinCode > MaxCode orelse
-                                         MinCode < 1 orelse
-                                         MaxCode < 1 ->
-    {error, invalid_message_code_range};
 register(Module, MinCode, MaxCode) ->
-    Registrations = dispatch_table(),
-    IsRegistered = fun(I) -> dict:is_key(I, Registrations) end,
-    CodeRange = lists:seq(MinCode, MaxCode),
-    case lists:filter(IsRegistered, CodeRange) of
-        [] ->
-            NewRegs = lists:foldl(fun(I, D) ->
-                                          dict:store(I, Module, D)
-                                  end, Registrations, CodeRange),
-            application:set_env(riak_api, services, NewRegs),
-            riak_api_pb_sup:service_registered(Module),
-            ok;
-        AlreadyClaimed ->
-            {error, {already_registered, AlreadyClaimed}}
-    end.
+    register([{Module, MinCode, MaxCode}]).
 
 %% @doc Removes the registration of a number of services modules at
 %% once.
@@ -116,47 +93,22 @@ register(Module, MinCode, MaxCode) ->
 -spec deregister([registration()]) -> ok | {error, Reason::term()}.
 deregister([]) ->
     ok;
-deregister([{Module, MinCode, MaxCode}|Rest]) ->
-    case deregister(Module, MinCode, MaxCode) of
-        ok ->
-            deregister(Rest);
-        Other ->
-            Other
-    end.
+deregister(List) ->
+    riak_api_pb_registrar:deregister(List).
 
 %% @doc Removes the registration of a previously-registered service
 %% module. Inputs will be validated such that the registered module
 %% must match the one being removed.
 -spec deregister(Module::module(), Code::pos_integer()) -> ok | {error, Err::term()}.
 deregister(Module, Code) ->
-    Registrations = dispatch_table(),
-    case dict:find(Code, Registrations) of
-        error ->
-            {error, {unregistered, Code}};
-        {ok, Module} ->
-            NewRegs = dict:erase(Code, Registrations),
-            application:set_env(riak_api, services, NewRegs),
-            riak_api_pb_sup:service_registered(Module),
-            ok;
-        {ok, _OtherModule} ->
-            {error, {not_owned, Code}}
-    end.
+    deregister([{Module, Code, Code}]).
 
 %% @doc Removes the registration of a previously-registered service
 %% module.
 %% @see deregister/2
 -spec deregister(Module::module(), MinCode::pos_integer(), MaxCode::pos_integer()) -> ok | {error, Err::term()}.
-deregister(_Module, MinCode, MaxCode) when MaxCode < MinCode ->
-    {error, invalid_message_code_range};
-deregister(Module, Code, Code) ->
-    deregister(Module, Code);
 deregister(Module, MinCode, MaxCode) ->
-    case deregister(Module, MinCode) of
-        ok ->
-            deregister(Module, MinCode + 1, MaxCode);
-        Error ->
-            Error
-    end.
+    deregister([{Module, MinCode, MaxCode}]).
 
 %% @doc Returns the current mappings from message codes to service
 %% modules. This is called by riak_api_pb_socket on startup so that
@@ -170,76 +122,3 @@ dispatch_table() ->
 -spec services() -> [ module() ].
 services() ->
     lists:usort([ V || {_K,V} <- dict:to_list(dispatch_table()) ]).
-
--ifdef(TEST).
-
-setup() ->
-    OldServices = app_helper:get_env(riak_api, services, dict:new()),
-    application:set_env(riak_api, services, dict:new()),
-    OldServices.
-
-cleanup(Services) ->
-    application:set_env(riak_api, services, Services).
-
-deregister_test_() ->
-    {foreach,
-     fun setup/0,
-     fun cleanup/1,
-     [
-      %% Deregister a previously registered service
-      ?_assertEqual(ok, begin
-                            ok = register(foo, 1, 2),
-                            deregister(foo, 1, 2)
-                        end),
-      %% Invalid deregistration: range is invalid
-      ?_assertEqual({error, invalid_message_code_range}, deregister(foo, 2, 1)),
-      %% Invalid deregistration: unregistered range
-      ?_assertEqual({error, {unregistered, 1}}, deregister(foo, 1, 1)),
-      %% Invalid deregistration: registered to other service
-      ?_assertEqual({error, {not_owned, 1}}, begin
-                                                 ok = register(foo, 1, 2),
-                                                 deregister(bar, 1)
-                                             end),
-      %% Deregister multiple
-      ?_assertEqual(ok, begin
-                            ok = register([{foo, 1, 2}, {bar, 3, 4}]),
-                            deregister([{bar, 3, 4}, {foo, 1, 2}])
-                        end)
-     ]}.
-
-register_test_() ->
-    {foreach,
-     fun setup/0,
-     fun cleanup/1,
-     [
-      %% Valid registration range
-      ?_assertEqual(foo, begin
-                             ok = register(foo,1,2),
-                             dict:fetch(1, dispatch_table())
-                         end),
-      %% Registration ranges that are invalid
-      ?_assertEqual({error, invalid_message_code_range},
-                    register(foo, 2, 1)),
-      ?_assertEqual({error, {already_registered, [1, 2]}},
-                    begin
-                        ok = register(foo, 1, 2),
-                        register(bar, 1, 3)
-                    end),
-      %% Register multiple
-      ?_assertEqual(ok, register([{foo, 1, 2}, {bar, 3, 4}]))
-     ]}.
-
-services_test_() ->
-    {setup,
-     fun setup/0,
-     fun cleanup/1,
-     [
-      ?_assertEqual([], services()),
-      ?_assertEqual([bar, foo], begin
-                                    register(foo, 1, 2),
-                                    register(bar, 3, 4),
-                                    services()
-                                end)
-     ]}.
-
--endif.

--- a/src/riak_api_sup.erl
+++ b/src/riak_api_sup.erl
@@ -47,10 +47,11 @@ init([]) ->
     Port = riak_api_pb_listener:get_port(),
     IP = riak_api_pb_listener:get_ip(),
     IsPbConfigured = (Port /= undefined) andalso (IP /= undefined),
-    Processes = if IsPbConfigured ->
-                        [?CHILD(riak_api_pb_sup, supervisor),
-                         ?CHILD(riak_api_pb_listener, worker, [IP, Port])];
-                   true ->
-                        []
-                end,
-    {ok, {{one_for_one, 10, 10}, Processes}}.
+    Registrar = ?CHILD(riak_api_pb_registrar, worker),
+    NetworkProcesses = if IsPbConfigured ->
+                               [?CHILD(riak_api_pb_sup, supervisor),
+                                ?CHILD(riak_api_pb_listener, worker, [IP, Port])];
+                          true ->
+                               []
+                       end,
+    {ok, {{one_for_one, 10, 10}, [Registrar|NetworkProcesses]}}.

--- a/test/pb_service_test.erl
+++ b/test/pb_service_test.erl
@@ -85,10 +85,10 @@ setup() ->
     application:set_env(riak_api, services, dict:new()),
     application:set_env(riak_api, pb_ip, "127.0.0.1"),
     application:set_env(riak_api, pb_port, 32767),
-    riak_api_pb_service:register(?MODULE, ?MSGMIN, ?MSGMAX),
 
     [ application:start(A) || A <- Deps ],
     wait_for_port(),
+    riak_api_pb_service:register(?MODULE, ?MSGMIN, ?MSGMAX),
     {OldServices, OldHost, OldPort, Deps}.
 
 cleanup({S, H, P, Deps}) ->

--- a/test/pb_service_test.erl
+++ b/test/pb_service_test.erl
@@ -215,11 +215,12 @@ dep_apps(App) ->
     {ok, Apps} = application:get_key(App, applications),
     Apps.
 
-all_deps(App) ->
-    [[ all_deps(Dep) || Dep <- dep_apps(App) ],App].
+all_deps(App, Deps) ->
+    [[ all_deps(Dep, [App|Deps]) || Dep <- dep_apps(App),
+                                    not lists:member(Dep, Deps)], App].
 
 resolve_deps(App) ->
-    DepList = lists:flatten(all_deps(App)),
+    DepList = all_deps(App, []),
     {AppOrder, _} = lists:foldl(fun(A,{List,Set}) ->
                                         case sets:is_element(A, Set) of
                                             true ->


### PR DESCRIPTION
Applications that proved PB services should deregister them when shutting down so as to leave a clean state. This also helps when running test suites that start/stop those applications.

Replacing #4, this also serializes registration and deregistration through a `gen_server` process, making the modification of the dispatch table less prone to race conditions.

See also: basho/riak_kv#353, basho/riak_kv#354, basho/riak_search#116
