### PR TITLE
Supervisor needs to start riak_api_stat or riak_kv_stat is broken.

### DIFF
--- a/src/riak_api_sup.erl
+++ b/src/riak_api_sup.erl
@@ -48,10 +48,11 @@ init([]) ->
     IP = riak_api_pb_listener:get_ip(),
     IsPbConfigured = (Port /= undefined) andalso (IP /= undefined),
     Registrar = ?CHILD(riak_api_pb_registrar, worker),
+    Stat = ?CHILD(riak_api_stat, worker, []),
     NetworkProcesses = if IsPbConfigured ->
                                [?CHILD(riak_api_pb_sup, supervisor),
                                 ?CHILD(riak_api_pb_listener, worker, [IP, Port])];
                           true ->
                                []
                        end,
-    {ok, {{one_for_one, 10, 10}, [Registrar|NetworkProcesses]}}.
+    {ok, {{one_for_one, 10, 10}, [Registrar,Stat|NetworkProcesses]}}.


### PR DESCRIPTION
I may misunderstand how this is supposed to work, but I think we need riak_api_stat running.

Lots of this...

```
19:44:56.156 [info] Unable to get stats for 'riak@r1s13.bos1': {error,{function_clause,[{proplists,get_value,[one,{error,{riak_api,pbc_connects},nonexistent_metric},undefined],[{file,"proplists.erl"},{line,222}]},{riak_kv_stat,backwards_compat,3,[{file,"src/riak_kv_stat.erl"},{line,337}]},{riak_kv_stat,backwards_compat_pb,1,[{file,"src/riak_kv_stat.erl"},{line,334}]},{riak_kv_stat,produce_stats,0,[{file,"src/riak_kv_stat.erl"},{line,316}]},{timer,tc,3,[{file,"timer.erl"},{line,194}]},{folsom_metrics,histogram_timed_update,4,[{file,"src/folsom_metrics.erl"},{line,163}]},{riak_core_stat_cache,'-do_get_stats/2-fun-0-',4,[{file,"src/riak_core_stat_cache.erl"},{line,183}]}]}}
19:44:56.157 [error] Error in process <0.4074.0> on node 'riak@r1s13.bos1' with exit value: {function_clause,[{proplists,get_value,[one,{error,{riak_api,pbc_connects},nonexistent_metric},undefined],[{file,"proplists.erl"},{line,222}]},{riak_kv_stat,backwards_compat,3,[{file,"src/riak_kv_stat.erl"},{line,337}]},{riak_kv_stat...
```
