### PR TITLE
Restore stat mod registration

### DIFF
--- a/src/riak_api_app.erl
+++ b/src/riak_api_app.erl
@@ -46,7 +46,6 @@ start(_Type, _StartArgs) ->
     case riak_api_sup:start_link() of
         {ok, Pid} ->
             riak_core:register(riak_api, [{stat_mod, riak_api_stat}]),
-            wait_for_process(riak_api_pb_registrar),
             ok = riak_api_pb_service:register(?SERVICES),
             {ok, Pid};
         {error, Reason} ->
@@ -58,15 +57,3 @@ start(_Type, _StartArgs) ->
 stop(_State) ->
     ok = riak_api_pb_service:deregister(?SERVICES),
     ok.
-
-%% @doc Waits for a named process to start up. This way we make sure
-%% the registrar process is available before we try to register
-%% anything.
--spec wait_for_process(atom() | pid()) -> ok.
-wait_for_process(Proc) ->
-    case erlang:whereis(Proc) of
-        undefined ->
-            timer:sleep(1000),
-            wait_for_process(Proc);
-        _Pid -> ok
-    end.

--- a/src/riak_api_pb_registrar.erl
+++ b/src/riak_api_pb_registrar.erl
@@ -170,7 +170,13 @@ do_deregister(Module, MinCode, MaxCode) ->
 -ifdef(TEST).
 
 test_start() ->
-    gen_server:start({local, ?SERVER}, ?MODULE, [], []).
+    case gen_server:start({local, ?SERVER}, ?MODULE, [], []) of
+        {error, {already_started, Pid}} ->
+            exit(Pid, brutal_kill),
+            test_start();
+        {ok, Pid} ->
+            {ok, Pid}
+    end.
 
 setup() ->
     OldServices = app_helper:get_env(riak_api, services, dict:new()),

--- a/test/pb_service_test.erl
+++ b/test/pb_service_test.erl
@@ -93,10 +93,10 @@ setup() ->
 
 cleanup({S, H, P, Deps}) ->
     [ application:stop(A) || A <- lists:reverse(Deps), not is_otp_base_app(A) ],
+    wait_for_application_shutdown(riak_api),
     application:set_env(riak_api, services, S),
     application:set_env(riak_api, pb_ip, H),
     application:set_env(riak_api, pb_port, P),
-    wait_for_application_shutdown(riak_api),
     ok.
 
 request(Code, Payload) when is_binary(Payload), is_integer(Code) ->


### PR DESCRIPTION
...and wait for the PB registrar to be available before returning from app startup.

Somehow in the deregistration branch the stat mod registration was removed. This puts it back, and reduces some of the race conditions around registrar startup that was returning `noproc` in the test suite.
