### PR TITLE
Allow multiple replies to be sent in the middle of a streaming operation.

### DIFF
--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -237,6 +237,10 @@ process_stream(Service, ReqId, Message, ServiceState0, State) ->
         {reply, Reply, ServiceState} ->
             send_encoded_message_or_error(Service, Reply, State),
             update_service_state(Service, ServiceState, State);
+        %% Stop the stream with multiple final replies
+        {done, Replies, ServiceState} when is_list(Replies) ->
+            [ send_encoded_message_or_error(Service, Reply, State) || Reply <- Replies ],
+            update_service_state(Service, ServiceState, State#state{req=undefined});
         %% Stop the stream with a final reply
         {done, Reply, ServiceState} ->
             send_encoded_message_or_error(Service, Reply, State),

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -229,6 +229,10 @@ process_stream(Service, ReqId, Message, ServiceState0, State) ->
         %% doesn't care about.
         {ignore, ServiceState} ->
             update_service_state(Service, ServiceState, State);
+        %% Sending multiple replies in middle-of-stream
+        {reply, Replies, ServiceState} when is_list(Replies) ->
+            [ send_encoded_message_or_error(Service, Reply, State) || Reply <- Replies ],
+            update_service_state(Service, ServiceState, State);
         %% Regular middle-of-stream messages
         {reply, Reply, ServiceState} ->
             send_encoded_message_or_error(Service, Reply, State),

--- a/src/riak_api_pb_service.erl
+++ b/src/riak_api_pb_service.erl
@@ -24,10 +24,134 @@
 %% application-specific interfaces exposed over the Protocol Buffers
 %% API. Service modules should implement the behaviour, and the host
 %% applications should register them on startup like so:
+%%
 %% <pre>
-%%   %% Register the 'ping' messages
-%%   ok = riak_api_pb_service:register(riak_core_pb_service, 1, 2)
+%%   %% Register a single range of message codes to the `foo' service
+%%   ok = riak_api_pb_service:register(foo, 101, 102),
+%%
+%%   %% Register multiple services at once
+%%   ok = riak_api_pb_service:register([{bar, 200, 210},
+%%                                      {baz, 211, 214}]).
 %% </pre>
+%%
+%% On shutdown, host applications should deregister services they
+%% registered on startup. The same arguments as were sent to
+%% `register/1,2,3' are valid arguments to `deregister/1,2,3'.
+%%
+%% <pre>
+%%    %% Deregister all my services
+%%    ok = riak_api_pb_service:deregister([{foo, 101, 102},
+%%                                         {bar, 200, 210},
+%%                                         {baz, 211, 214}]).
+%% </pre>
+%%
+%% == Behaviour Callbacks ==
+%%
+%% Service modules must export five callbacks:
+%%
+%% ```
+%% init() ->
+%%     State.
+%%
+%%     State = term()
+%% '''
+%%
+%% The `init/0' callback is called to create any state that the
+%% service may need to operate. The return value of this callback will
+%% be passed to the service in other callbacks.
+%%
+%% ```
+%% decode(Code, Message) ->
+%%     {ok, DecodedMessage} |
+%%     {error, Reason}.
+%%
+%%     Code = non_neg_integer()
+%%     Message = binary()
+%%     DecodedMessage = Reason = term()
+%% '''
+%%
+%% The `decode/2' callback is handed a message code and wire message
+%% that is registered to this service and should decode it into an
+%% Erlang term that can be handled by the `process/2' callback. If the
+%% message does not decode properly, it should return an `error' tuple
+%% with an appropriate reason. Most services will simply delegate
+%% encoding to the `riak_pb' application.
+%%
+%% ```
+%% encode(Message) ->
+%%     {ok, EncodedMessage} |
+%%     Error.
+%%
+%%     Message = Error = term()
+%%     EncodedMessage = iodata()
+%% '''
+%%
+%% The `encode/1' callback is given an Erlang term that is a reply
+%% message to a client and should encode that message as `iodata',
+%% including an appropriate message code on the head. Any return value
+%% other than `{ok, iodata()}' will be interpreted as an error. Again,
+%% most services will simply delegate encoding to the `riak_pb'
+%% application.
+%%
+%% ```
+%% process(Message, State) ->
+%%     {reply, ReplyMessage, NewState} |
+%%     {reply, {stream, ReqId}, NewState} |
+%%     {error, Error, NewState}.
+%%
+%%     Message = State = ReqId = ReplyMessage = NewState = term()
+%%     Error = iodata() | {format, term()} | {format, io:format(), [term()]}
+%% '''
+%%
+%% The `process/2' callback is where the work of servicing a client
+%% request is done. The return value of the `decode/2' callback will
+%% be passed as `Message' and the last value of the service state as
+%% `State' (as returned from `init/0' or a previous invocation of
+%% `process/2' or `process_stream/3'). The callback should return
+%% 3-tuples, any of which include the modified service state as the
+%% last entry. The first form is a simple reply in which a single
+%% message is returned to the client (passing through `encode/1' along
+%% the way). The second form moves the service into streaming mode,
+%% using the returned `ReqId' (see `process_stream/3').
+%%
+%% The third form replies with an error to the client, the second
+%% entry (`Error') becoming the `errmsg' field of the `rpberrorresp'
+%% message. If it is iodata, it will be passed verbatim to the client.
+%% If it is the `format' 2-tuple, it will be formatted with the "~p"
+%% format string before being sent to the client. If it is the
+%% `format' 3-tuple, the list of terms will be formatted against the
+%% format string before being sent to the client.
+%%
+%% ```
+%% process_stream(Message, ReqId, State) ->
+%%     {reply, Reply, NewState} |
+%%     {ignore, NewState} |
+%%     {done, Reply, NewState} |
+%%     {done, NewState} |
+%%     {error, Error, NewState}.
+%%
+%%     Message = ReqId = State = NewState = term()
+%%     Reply = [ term() ] | term()
+%%     Error = iodata() | {format, term()} | {format, io:format(), [term()]}
+%% '''
+%%
+%% The `process_stream/3' callback is invoked when the socket/server
+%% process receives a message from another Erlang process while in
+%% streaming mode. The passed `ReqId' is the value returned from
+%% `process/2' when streaming mode was started, and is usually used to
+%% identify or ignore incoming messages from other processes. Like
+%% `process/2', the state of the service is passed as the last
+%% argument.
+%%
+%% As with `process/2', the last entry of all return-value tuples
+%% should be the updated state of the service. Also, similarly to
+%% `process/2', a `reply' tuple will result in sending a normal
+%% message to the client. When `Reply' is a list, this will be
+%% interpreted as sending multiple messages to the client in one pass.
+%% Error tuples have similar semantics to `process/2', but will also
+%% cause the service to exit streaming mode. The `ignore' tuple will
+%% cause the server to do nothing. The `done' tuples signal a normal
+%% end to the streaming operation, with an optional reply to the client.
 %% @end
 
 -module(riak_api_pb_service).

--- a/src/riak_api_pb_service.erl
+++ b/src/riak_api_pb_service.erl
@@ -150,8 +150,9 @@
 %% interpreted as sending multiple messages to the client in one pass.
 %% Error tuples have similar semantics to `process/2', but will also
 %% cause the service to exit streaming mode. The `ignore' tuple will
-%% cause the server to do nothing. The `done' tuples signal a normal
-%% end to the streaming operation, with an optional reply to the client.
+%% cause the server to do nothing. The `done' tuples have the same
+%% semantics as `reply' (including multi-message replies) and `ignore'
+%% but signal a normal end of the streaming operation.
 %% @end
 
 -module(riak_api_pb_service).

--- a/test/pb_service_test.erl
+++ b/test/pb_service_test.erl
@@ -45,7 +45,7 @@ process(stream, State) ->
     Ref = make_ref(),
     spawn_link(fun() ->
                        Server ! {Ref, foo},
-                       Server ! {Ref, bar},
+                       Server ! {Ref, multi},
                        Server ! {Ref, done}
                end),
     {reply, {stream, Ref}, State};
@@ -58,6 +58,8 @@ process(dummyreq, State) ->
 
 process_stream({Ref,done}, Ref, State) ->
     {done, State};
+process_stream({Ref, multi}, Ref, State) ->
+    {reply, [foo, bar], State};
 process_stream({Ref,Msg}, Ref, State) ->
     {reply, Msg, State};
 process_stream(_, _, State) ->
@@ -138,7 +140,7 @@ simple_test_() ->
       %% Happy path, sync operation
       ?_assertEqual([102|<<"ok">>], request(101, <<>>)),
       %% Happy path, streaming operation
-      ?_assertEqual([{108, <<"foo">>},{109,<<"bar">>}],
+      ?_assertEqual([{108, <<"foo">>},{108, <<"foo">>},{109,<<"bar">>}],
                     request_stream(107, <<>>, fun([Code|_]) -> Code == 109 end)),
       %% Unknown request message code
       ?_assertMatch([0|Bin] when is_binary(Bin), request(105, <<>>)),


### PR DESCRIPTION
This removes the need for some circuitous code in basho/riak_kv#407 by allowing a service to reply with multiple messages resulting from processing a single stream message.

/cc @beerriot 
