### PR TITLE
Convert registration process to use ets

### DIFF
--- a/src/riak_api_pb_registrar.erl
+++ b/src/riak_api_pb_registrar.erl
@@ -111,7 +111,7 @@ init([]) ->
     {ok, #state{}}.
 
 handle_call({Op, Args}, From, #state{opq=OpQ, owned=false}=State) ->
-    %% Since we don't own the process yet, we enqueue the registration
+    %% Since we don't own the table yet, we enqueue the registration
     %% operations until we get the ETS-TRANSFER message.
     {noreply, State#state{opq=[{{Op, Args}, From}|OpQ]}};
 handle_call({set_heir, Pid}, _From, #state{owned=true}=State) ->

--- a/src/riak_api_pb_registrar.hrl
+++ b/src/riak_api_pb_registrar.hrl
@@ -1,3 +1,24 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_api_pb_registrar Header file
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
 -define(ETS_NAME, riak_api_pb_registrations).
 -define(ETS_HEIR, {heir, self(), undefined}).
 -define(ETS_OPTS, [protected,

--- a/src/riak_api_pb_registrar.hrl
+++ b/src/riak_api_pb_registrar.hrl
@@ -1,0 +1,7 @@
+-define(ETS_NAME, riak_api_pb_registrations).
+-define(ETS_HEIR, {heir, self(), undefined}).
+-define(ETS_OPTS, [protected,
+                   named_table,
+                   set,
+                   ?ETS_HEIR,
+                   {read_concurrency, true}]).

--- a/src/riak_api_pb_registration_helper.erl
+++ b/src/riak_api_pb_registration_helper.erl
@@ -168,7 +168,3 @@ terminate(_Reason, _State) ->
 -spec code_change(term(), term(), term()) -> {ok, term()}.
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================

--- a/src/riak_api_pb_registration_helper.erl
+++ b/src/riak_api_pb_registration_helper.erl
@@ -22,8 +22,8 @@
 
 %% @doc A gen_server process that creates and serves as heir to the
 %% message-code registration ETS table. Should the registrar process
-%% exit, this table will inherit the ETS table and hand it back to the
-%% registrar process when it restarts.
+%% exit, this server will inherit the ETS table and hand it back to
+%% the registrar process when it restarts.
 -module(riak_api_pb_registration_helper).
 
 -behaviour(gen_server).

--- a/src/riak_api_pb_registration_helper.erl
+++ b/src/riak_api_pb_registration_helper.erl
@@ -1,0 +1,174 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_api_pb_registration_helper: PB API Registration table manager
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc A gen_server process that creates and serves as heir to the
+%% message-code registration ETS table. Should the registrar process
+%% exit, this table will inherit the ETS table and hand it back to the
+%% registrar process when it restarts.
+-module(riak_api_pb_registration_helper).
+
+-behaviour(gen_server).
+
+-include("riak_api_pb_registrar.hrl").
+
+%% API
+-export([start_link/0,
+         claim_table/0]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the server
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec start_link() -> {ok, Pid::pid()} | ignore | {error, Error::term()}.
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Gives the registration table away to the caller, which should be
+%% the registrar process.
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec claim_table() -> ok.
+claim_table() ->
+    gen_server:call(?SERVER, claim_table, infinity).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Initializes the server
+%% @end
+%%--------------------------------------------------------------------
+-spec init([]) -> {ok, undefined}.
+init([]) ->
+    case ets:info(?ETS_NAME) of
+        undefined ->
+            %% Table does not exist, so we create the table and wait
+            %% for the registrar to claim it.
+            ets:new(?ETS_NAME, ?ETS_OPTS),
+            {ok, undefined};
+        List when is_list(List) ->
+            %% This process must have been restarted, because the table
+            %% already exists. Let's try to become the heir again.
+            lager:debug("PB registration helper restarted as ~p, becoming heir", [self()]),
+            riak_api_pb_registrar:set_heir(self()),
+            {ok, undefined}
+    end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling call messages
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_call(Msg::term(), From::{pid(), term()}, State::term()) ->
+                         {reply, Reply::term(), State::term()} |
+                         {noreply, State::term()}.
+handle_call(claim_table, {Pid, _Tag}, State) ->
+    %% The registrar is (re-)claiming the table, let's give it away. We
+    %% assume this process is the heir, which is set on startup or
+    %% transfer of the table.
+    lager:debug("Giving away PB registration table to ~p", [Pid]),
+    ets:give_away(?ETS_NAME, Pid, undefined),
+    Reply = ok,
+    {reply, Reply, State};
+
+handle_call(_Msg, _From, State) ->
+    {noreply, State}.
+
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling cast messages
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_cast(term(), term()) -> {noreply, State::term()}.
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%%
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+-spec handle_info(term(), term()) -> {noreply, State::term()}.
+handle_info({'ETS-TRANSFER', ?ETS_NAME, FromPid, _HeirData}, State) ->
+    %% The registrar process exited and transferred the table back to
+    %% the helper.
+    lager:debug("PB Registrar ~p exited, ~p received table", [FromPid, self()]),
+    {noreply, State};
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec terminate(term(), term()) -> ok.
+terminate(_Reason, _State) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec code_change(term(), term(), term()) -> {ok, term()}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/src/riak_api_pb_service.erl
+++ b/src/riak_api_pb_service.erl
@@ -44,10 +44,6 @@
          deregister/2,
          deregister/3]).
 
-%% Server API
--export([dispatch_table/0,
-         services/0]).
-
 -type registration() :: {Service::module(), MinCode::pos_integer(), MaxCode::pos_integer()}.
 
 -export_type([registration/0]).
@@ -109,16 +105,3 @@ deregister(Module, Code) ->
 -spec deregister(Module::module(), MinCode::pos_integer(), MaxCode::pos_integer()) -> ok | {error, Err::term()}.
 deregister(Module, MinCode, MaxCode) ->
     deregister([{Module, MinCode, MaxCode}]).
-
-%% @doc Returns the current mappings from message codes to service
-%% modules. This is called by riak_api_pb_socket on startup so that
-%% dispatches don't hit the application env.
--spec dispatch_table() -> dict().
-dispatch_table() ->
-    app_helper:get_env(riak_api, services, dict:new()).
-
-%% @doc Returns the current registered PB services, based on the
-%% dispatch_table().
--spec services() -> [ module() ].
-services() ->
-    lists:usort([ V || {_K,V} <- dict:to_list(dispatch_table()) ]).

--- a/src/riak_api_sup.erl
+++ b/src/riak_api_sup.erl
@@ -47,6 +47,7 @@ init([]) ->
     Port = riak_api_pb_listener:get_port(),
     IP = riak_api_pb_listener:get_ip(),
     IsPbConfigured = (Port /= undefined) andalso (IP /= undefined),
+    Helper = ?CHILD(riak_api_pb_registration_helper, worker),
     Registrar = ?CHILD(riak_api_pb_registrar, worker),
     NetworkProcesses = if IsPbConfigured ->
                                [?CHILD(riak_api_pb_sup, supervisor),
@@ -54,4 +55,4 @@ init([]) ->
                           true ->
                                []
                        end,
-    {ok, {{one_for_one, 10, 10}, [Registrar|NetworkProcesses]}}.
+    {ok, {{one_for_one, 10, 10}, [Helper, Registrar|NetworkProcesses]}}.

--- a/test/pb_service_test.erl
+++ b/test/pb_service_test.erl
@@ -79,22 +79,19 @@ setup() ->
 
     application:set_env(riak_core, handoff_port, 0),
 
-    OldServices = riak_api_pb_service:dispatch_table(),
     OldHost = app_helper:get_env(riak_api, pb_ip, "127.0.0.1"),
     OldPort = app_helper:get_env(riak_api, pb_port, 8087),
-    application:set_env(riak_api, services, dict:new()),
     application:set_env(riak_api, pb_ip, "127.0.0.1"),
     application:set_env(riak_api, pb_port, 32767),
 
     [ application:start(A) || A <- Deps ],
     wait_for_port(),
     riak_api_pb_service:register(?MODULE, ?MSGMIN, ?MSGMAX),
-    {OldServices, OldHost, OldPort, Deps}.
+    {OldHost, OldPort, Deps}.
 
-cleanup({S, H, P, Deps}) ->
+cleanup({H, P, Deps}) ->
     [ application:stop(A) || A <- lists:reverse(Deps), not is_otp_base_app(A) ],
     wait_for_application_shutdown(riak_api),
-    application:set_env(riak_api, services, S),
     application:set_env(riak_api, pb_ip, H),
     application:set_env(riak_api, pb_port, P),
     ok.


### PR DESCRIPTION
Our previous strategy for (de-)registration used the application environment and a dict to store the mappings from message codes to service modules. This became problematic when the node is shutting down because you can't set the appenv at that time. 

We already serialize changes to this state through a gen_server process, so there's no reason why it can't manage the state itself, rather than in the application environment. To make this happen, a few [process-gymnastics are needed](http://steve.vinoski.net/blog/2011/03/23/dont-lose-your-ets-tables/).
1. On application startup, the ets table is created by a new process `riak_api_pb_registration_helper` that serves solely as the table heir. The ets options allow read-only concurrent access from multiple processes. This simplifies management of message-code/service mappings and reduces the memory usage of each connection process (fewer dicts).
2. When the registrar crashes, the helper will inherit the table. On (re-)start, the registrar will request the table from the helper, at which point the helper will give away the table to the new registrar.
3. When the helper crashes, the heir setting on the table is nullified automatically by the emulator. On restart, the helper will attempt to create the table if it does not exist, or otherwise ask the registrar to become the heir.
4. The `services/0` and `dispatch_table/0` functions were removed from riak_api_pb_service as they are no longer necessary. `services/0` was added to `riak_api_pb_registrar`.
5. For additional safety, deregistration is wrapped in a try/catch so that if the registrar has already shut down, the `noproc` exit is silently ignored.
