### PR TITLE
Use riak_api_pb_sup active children count for pb active stat

### DIFF
--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -177,7 +177,6 @@ handle_info(Message, State) ->
       Reason :: normal | shutdown | {shutdown,term()} | term(),
       State :: #state{}.
 terminate(_Reason, _State) ->
-    riak_api_stat:update(pbc_disconnect),
     ok.
 
 %% @doc The gen_server code_change/3 callback, called when performing


### PR DESCRIPTION
Since a crashing connection will not call the terminate fun
calls to decrement the `active` counter did not occur and
the `pbc_active` stat did not shrink appropriately. This fixes that.
