### PR TITLE
Performance improvements

### DIFF
--- a/src/riak_api_pb_frame.erl
+++ b/src/riak_api_pb_frame.erl
@@ -1,0 +1,50 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_api_pb_frame: framing assistance for TCP responses
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(riak_api_pb_frame).
+
+-export([new/0,
+         add/2]).
+
+-record(buffer, {
+          buffer = [] :: iodata(),
+          size = 0 :: non_neg_integer(),
+          max_size = 1024 :: non_neg_integer()
+         }).
+
+-type buffer() :: #buffer{}.
+-export_type([buffer/0]).
+
+-spec new() -> buffer().
+new() ->
+    #buffer{}.
+
+-spec add(iodata(), buffer()) -> {ok, buffer()} | {flush, iodata(), buffer()}.
+add(Message, #buffer{buffer = Buffer, size = Size, max_size = Max}) ->
+    MessageSize = iolist_size(Message),
+    NewSize = MessageSize + 4 + Size,
+    NewBuffer = [[<<MessageSize:32/unsigned-big-integer>>,Message]|Buffer],
+    if
+        NewSize >= Max -> 
+            {flush, lists:reverse(NewBuffer), #buffer{}};
+        true -> 
+            {ok, #buffer{buffer=NewBuffer, size=NewSize}}
+    end.

--- a/src/riak_api_pb_listener.erl
+++ b/src/riak_api_pb_listener.erl
@@ -46,7 +46,7 @@ init([PortNum]) ->
 sock_opts() ->
     BackLog = app_helper:get_env(riak_api, pb_backlog, 5),
     NoDelay = app_helper:get_env(riak_api, disable_pb_nagle, false),
-    [binary, {packet, 4}, {reuseaddr, true}, {backlog, BackLog}, {nodelay, NoDelay}].
+    [binary, {packet, raw}, {reuseaddr, true}, {backlog, BackLog}, {nodelay, NoDelay}].
 
 %% @doc The handle_call/3 gen_nb_server callback. Unused.
 -spec handle_call(term(), pid(), #state{}) -> {reply, term(), #state{}}.

--- a/src/riak_api_pb_listener.erl
+++ b/src/riak_api_pb_listener.erl
@@ -81,7 +81,7 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
 %% @doc The connection initiation callback for gen_nb_server, called
 %% when a new socket is accepted.
--spec new_connection(gen_tcp:socket(), #state{}) -> {ok, #state{}}.
+-spec new_connection(port(), #state{}) -> {ok, #state{}}.
 new_connection(Socket, State) ->
     {ok, Pid} = riak_api_pb_sup:start_socket(),
     ok = gen_tcp:controlling_process(Socket, Pid),
@@ -100,7 +100,7 @@ get_port() ->
                           " deprecated and will be removed.  Use"
                           " riak_api/pb_port in the future."),
             Port;
-        {default, undefined} ->
+        _ ->
             lager:warning("The config riak_api/pb_port is missing,"
                           " PB connections will be disabled."),
             undefined
@@ -118,7 +118,7 @@ get_ip() ->
                           " deprecated and will be removed.  Use"
                           " riak_api/pb_ip in the future."),
             IP;
-        {default, undefined} ->
+        _ ->
             lager:warning("The config riak_api/pb_ip is missing,"
                           " PB connections will be disabled."),
             undefined

--- a/src/riak_api_pb_listener.erl
+++ b/src/riak_api_pb_listener.erl
@@ -45,7 +45,7 @@ init([PortNum]) ->
 -spec sock_opts() -> [gen_tcp:option()].
 sock_opts() ->
     BackLog = app_helper:get_env(riak_api, pb_backlog, 5),
-    NoDelay = app_helper:get_env(riak_api, disable_pb_nagle, true),
+    NoDelay = app_helper:get_env(riak_api, disable_pb_nagle, false),
     [binary, {packet, 4}, {reuseaddr, true}, {backlog, BackLog}, {nodelay, NoDelay}].
 
 %% @doc The handle_call/3 gen_nb_server callback. Unused.

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -79,7 +79,7 @@ handle_call({set_socket, Socket}, _From, State) ->
     {reply, ok, State#state{socket = Socket}}.
 
 %% @doc The handle_cast/2 gen_server callback.
--spec handle_cast(Message::term(), State::#state{}) -> {noreply, NewState::#state{}}.
+-spec handle_cast(Message::term(), State::#state{}) -> {noreply, NewState::#state{}, timeout()}.
 handle_cast({registered, Service}, #state{states=ServiceStates}=State) ->
     %% When a new service is registered after a client connection is
     %% already established, update the internal state to support the


### PR DESCRIPTION
Results of a long back-and-forth session with @Vagabond. Taken with basho/erlang_protobuffs#38, this should greatly improve the performance of streaming requests especially.
1. Services are small in number, use `orddict` instead of `dict` to store the state of individual services within a server process.
2. Reduce number of calls to `orddict:fetch` and `orddict:store`. This is accomplished by avoiding storing the service state when it is unchanged, and by keeping the state of a service in streaming mode in the current request state and only storing it when the stream finishes.
3. Reduce number of calls to `gen_tcp:send/2` by buffering outgoing messages up to ~1KB. When the server has no more Erlang messages in its message queue, or the buffer fills, the buffer will be flushed to the socket.
