### PR TITLE
Late vnode replies show up as errors in the logs

### DIFF
--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -158,6 +158,9 @@ handle_info(StreamMessage, #state{req={Service,ReqId},
                        [Type, Reason, Trace], State),
             {stop, {Type, Reason, Trace}, State}
     end;
+handle_info({Ref, {ok, _RiakObj}}, State) when is_integer(Ref) ->
+    lager:info("Received late get response", []),
+    {noreply, State};
 handle_info(Message, State) ->
     %% Throw out messages we don't care about, but log them
     lager:error("Unrecognized message ~p", [Message]),


### PR DESCRIPTION
When a cluster is heavily loaded, sometimes a vnode will not respond within the client's receive timeout.  In webmachine this isn't a problem, since the receiving pid is dead after the request is finished and the message is dropped.  But since the pbc interface calls gets from a long-running pid, the gen_server must occasionally deal with these messages when it gets them.  

So:
- add a non-error handle_info clause for vnode replies that reach this process after a get's receive timeout has expired.
- log those as info with a clearer message
