### PR TITLE
Move setting/fetching bucket properties out of riak_kv

### DIFF
--- a/src/riak_api_app.erl
+++ b/src/riak_api_app.erl
@@ -28,7 +28,11 @@
          stop/1]).
 
 -define(SERVICES, [{riak_api_basic_pb_service, 1, 2},
-                   {riak_api_basic_pb_service, 7, 8}]).
+                   {riak_api_basic_pb_service, 7, 8},
+                   %% Note: Riak core cannot register this itself,
+                   %% because it is started before riak_api.
+                   {riak_core_pb_bucket, 19, 22}
+                  ]).
 
 %% @doc The application:start callback.
 -spec start(Type, StartArgs)

--- a/src/riak_core_pb_bucket.erl
+++ b/src/riak_core_pb_bucket.erl
@@ -1,0 +1,87 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_core_pb_bucket: Expose Core bucket functionality to Protocol Buffers
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc <p>The Bucket PB service for Riak Core. This is included in
+%% the Riak API application because of startup-time constraints. This
+%% service covers the following request messages in the original
+%% protocol:</p>
+%%
+%% <pre>
+%% 19 - RpbGetBucketReq
+%% 21 - RpbSetBucketReq
+%% </pre>
+%%
+%% <p>This service produces the following responses:</p>
+%%
+%% <pre>
+%% 20 - RpbGetBucketResp
+%% 22 - RpbSetBucketResp
+%% </pre>
+%%
+%% <p>The semantics are unchanged from their original
+%% implementations.</p>
+%% @end
+-module(riak_core_pb_bucket).
+
+-behaviour(riak_api_pb_service).
+
+-export([init/0,
+         decode/2,
+         encode/1,
+         process/2,
+         process_stream/3]).
+
+-include_lib("riak_pb/include/riak_pb.hrl").
+
+-record(state, {client}).
+
+init() ->
+    #state{client = riak:local_client()}.
+
+%% @doc decode/2 callback. Decodes an incoming message.
+decode(Code, Bin) when Code == 19; Code == 21 ->
+    {ok, riak_pb_codec:decode(Code, Bin)}.
+
+%% @doc encode/1 callback. Encodes an outgoing response message.
+encode(Message) ->
+    {ok, riak_pb_codec:encode(Message)}.
+
+%% Get bucket properties
+process(#rpbgetbucketreq{bucket=B},
+        #state{client=C} = State) ->
+    Props = C:get_bucket(B),
+    PbProps = riak_pb_codec:encode_bucket_props(Props),
+    {reply, #rpbgetbucketresp{props = PbProps}, State};
+
+%% Set bucket properties
+process(#rpbsetbucketreq{bucket=B, props = PbProps},
+        #state{client=C} = State) ->
+    Props = riak_pb_codec:decode_bucket_props(PbProps),
+    case C:set_bucket(B, Props) of
+        ok ->
+            {reply, rpbsetbucketresp, State};
+        {error, Details} ->
+            {error, {format, "Invalid bucket properties: ~p", [Details]}, State}
+    end.
+
+process_stream(_, _, State) ->
+    {ignore, State}.

--- a/src/riak_core_pb_bucket.erl
+++ b/src/riak_core_pb_bucket.erl
@@ -52,10 +52,8 @@
 
 -include_lib("riak_pb/include/riak_pb.hrl").
 
--record(state, {client}).
-
 init() ->
-    #state{client = riak:local_client()}.
+    undefined.
 
 %% @doc decode/2 callback. Decodes an incoming message.
 decode(Code, Bin) when Code == 19; Code == 21 ->
@@ -66,17 +64,15 @@ encode(Message) ->
     {ok, riak_pb_codec:encode(Message)}.
 
 %% Get bucket properties
-process(#rpbgetbucketreq{bucket=B},
-        #state{client=C} = State) ->
-    Props = C:get_bucket(B),
+process(#rpbgetbucketreq{bucket=B}, State) ->
+    Props = riak_core_bucket:get_bucket(B),
     PbProps = riak_pb_codec:encode_bucket_props(Props),
     {reply, #rpbgetbucketresp{props = PbProps}, State};
 
 %% Set bucket properties
-process(#rpbsetbucketreq{bucket=B, props = PbProps},
-        #state{client=C} = State) ->
+process(#rpbsetbucketreq{bucket=B, props = PbProps}, State) ->
     Props = riak_pb_codec:decode_bucket_props(PbProps),
-    case C:set_bucket(B, Props) of
+    case riak_core_bucket:set_bucket(B, Props) of
         ok ->
             {reply, rpbsetbucketresp, State};
         {error, Details} ->


### PR DESCRIPTION
While this could be in [riak_core](/basho/riak_core), this solution results in a simpler startup sequence and doesn't add any additional or circular dependencies into riak_core.

Required: basho/riak_pb#30
