### PR TITLE
Remove lager dependency because it is specified by riak_core.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,6 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {lager, ".*", {git, "git://github.com/basho/lager.git", {tag, "1.2.2"}}},
         {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", "master"}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", "master"}}
         ]}.


### PR DESCRIPTION
Pursuant to our dependency/tagging discussion.

@jaredmorrow @reiddraper @Vagabond 
