### PR TITLE
Fix stat names so delete of stats on restart works

### DIFF
--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -45,8 +45,11 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    [(catch folsom_metrics:delete_metric({?APP, Name})) || {Name, _Type} <- stats()],
-    [register_stat(stat_name(Stat), Type) || {Stat, Type} <- stats()],
+    [begin
+         StatName = stat_name(Name),
+         (catch folsom_metrics:delete_metric(StatName)),
+         register_stat(StatName, Type)
+     end || {Name, Type} <- stats()],
     riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
 
 %% @doc Return current aggregation of all stats.


### PR DESCRIPTION
Folsom can get inconsistent. When it does stat updates will fail.
When a stat update fails the stat server crashes. Deleting on
start up is a way to get folsom consistent again.

This commit fixes a bug where the api stats were not all
deleted due to using the wrong stat name format.
