### PR TITLE
No PB listeners leads to repeated log messages concerning a failed stat calculation

### DIFF
--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -115,4 +115,9 @@ register_stat(Name, {function, _Module, _Function}=Fun) ->
     folsom_metrics:notify({Name, Fun}).
 
 active_pb_connects() ->
-    proplists:get_value(active, supervisor:count_children(riak_api_pb_sup)).
+    %% riak_api_pb_sup will not be running when there are no listeners
+    %% defined.
+    case erlang:whereis(riak_api_pb_sup) of
+        undefined -> 0;
+        _ -> proplists:get_value(active, supervisor:count_children(riak_api_pb_sup))
+    end.


### PR DESCRIPTION
When no PB Listeners are configured, repeated log messages concerning a failed stat calculation are output:

```
23:09:59.144 [warning] Failed to calculate stat {riak_api,pbc_connects,active} with exit:{noproc,{gen_server,call,[riak_api_pb_sup,count_children,infinity]}}
23:10:00.225 [warning] Failed to calculate stat {riak_api,pbc_connects,active} with exit:{noproc,{gen_server,call,[riak_api_pb_sup,count_children,infinity]}}
23:10:01.300 [warning] Failed to calculate stat {riak_api,pbc_connects,active} with exit:{noproc,{gen_server,call,[riak_api_pb_sup,count_children,infinity]}}
23:10:02.373 [warning] Failed to calculate stat {riak_api,pbc_connects,active} with exit:{noproc,{gen_server,call,[riak_api_pb_sup,count_children,infinity]}}
23:10:03.251 [warning] Failed to calculate stat {riak_api,pbc_connects,active} with exit:{noproc,{gen_server,call,[riak_api_pb_sup,count_children,infinity]}}
23:10:03.448 [warning] Failed to calculate stat {riak_api,pbc_connects,active} with exit:{noproc,{gen_server,call,[riak_api_pb_sup,count_children,infinity]}}
```
