### PR TITLE
Move webmachine from riak_core.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,5 +3,6 @@
 {eunit_opts, [verbose]}.
 {deps, [
         {riak_pb, "2.0.0.3", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.3"}}},
+        {webmachine, "1.10.3", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.3"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}}
         ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,6 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_pb, "1.4.1.1", {git, "git://github.com/basho/riak_pb.git", {tag, "1.4.1.1"}}},
+        {riak_pb, "1.4.1.2", {git, "git://github.com/basho/riak_pb.git", {tag, "1.4.1.2"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}}
         ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,6 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_pb, "1.4.1.1", {git, "git://github.com/basho/riak_pb.git", {tag, "1.4.1.1"}}},
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "master"}}}
+        {riak_pb, "1.4.1.1", {git, "git://github.com/basho/riak_pb.git", {branch, "develop"}}},
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}}
         ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,6 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_pb, "1.4.1.1", {git, "git://github.com/basho/riak_pb.git", {branch, "develop"}}},
+        {riak_pb, "1.4.1.1", {git, "git://github.com/basho/riak_pb.git", {tag, "1.4.1.1"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}}
         ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,6 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_pb, "1.4.1.2", {git, "git://github.com/basho/riak_pb.git", {tag, "1.4.1.2"}}},
+        {riak_pb, "2.0.0.3", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.3"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}}
         ]}.

--- a/src/riak_api_app.erl
+++ b/src/riak_api_app.erl
@@ -32,7 +32,8 @@
                    %% Note: Riak core cannot register this itself,
                    %% because it is started before riak_api.
                    {riak_core_pb_bucket, 19, 22},
-                   {riak_core_pb_bucket, 29, 30}
+                   {riak_core_pb_bucket, 29, 30},
+                   {riak_core_pb_bucket_type, 31, 33}
                   ]).
 
 %% @doc The application:start callback.

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -202,7 +202,8 @@ handle_message(MsgCode, MsgData, State=#state{states=ServiceStates}) ->
                         send_error("Message decoding error: ~p", [Reason], State)
                 end;
             error ->
-                send_error("Unknown message code.", State)
+                send_error(io_lib:format("Unknown message code: ~p",
+                                         [MsgCode]), State)
         end,
         {ok, NewState}
     catch

--- a/src/riak_api_web.erl
+++ b/src/riak_api_web.erl
@@ -1,0 +1,87 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_api_web: setup Riak's HTTP interface
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Convenience functions for setting up the HTTP interface
+%%      of Riak.
+-module(riak_api_web).
+
+
+-export([get_listeners/0,
+         binding_config/2]).
+
+get_listeners() ->
+    get_listeners(http) ++ get_listeners(https).
+
+get_listeners(Scheme) ->
+    APISetting = app_helper:get_env(riak_api, Scheme, []),
+    case app_helper:get_env(riak_core, Scheme, undefined) of
+        undefined ->
+            [ {Scheme, Binding} || Binding <- APISetting ];
+        List ->
+            lager:warning("Setting riak_core/~s is deprecated, please use riak_api/~s", [Scheme, Scheme]),
+            lists:usort([ {Scheme, Binding} || Binding <- List ++ APISetting ])
+    end.
+
+binding_config(Scheme, Binding) ->
+    {Ip, Port} = Binding,
+    Name = spec_name(Scheme, Ip, Port),
+    Config = spec_from_binding(Scheme, Name, Binding),
+
+    {Name,
+     {webmachine_mochiweb, start, [Config]},
+     permanent, 5000, worker, [mochiweb_socket_server]}.
+
+spec_from_binding(http, Name, {Ip, Port}) ->
+    lists:flatten([{name, Name},
+                   {ip, Ip},
+                   {port, Port},
+                   {nodelay, true}],
+                  common_config());
+
+spec_from_binding(https, Name, {Ip, Port}) ->
+    Etc = app_helper:get_env(riak_core, platform_etc_dir, "etc"),
+    SslOpts = app_helper:get_env(riak_core, ssl,
+                                 [{certfile, filename:join(Etc, "cert.pem")},
+                                  {keyfile, filename:join(Etc, "key.pem")}]),
+    lists:flatten([{name, Name},
+                   {ip, Ip},
+                   {port, Port},
+                   {ssl, true},
+                   {ssl_opts, SslOpts},
+                   {nodelay, true}],
+                  common_config()).
+
+spec_name(Scheme, Ip, Port) ->
+    FormattedIP = if is_tuple(Ip); tuple_size(Ip) == 4 ->
+                          inet_parse:ntoa(Ip);
+                     is_tuple(Ip); tuple_size(Ip) == 8 ->
+                          [$[, inet_parse:ntoa(Ip), $]];
+                     true -> Ip
+                  end,
+    lists:flatten(io_lib:format("~s://~s:~p", [Scheme, FormattedIP, Port])).
+
+common_config() ->
+    [{log_dir, app_helper:get_env(riak_api, http_logdir,
+                                  app_helper:get_env(riak_core, platform_log_dir, "log"))},
+     {backlog, 128},
+     {dispatch, [{[], riak_api_wm_urlmap, []}
+                ]}].

--- a/src/riak_api_wm_urlmap.erl
+++ b/src/riak_api_wm_urlmap.erl
@@ -1,0 +1,81 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_api_wm_urlmap: expose the roots of registered Webmachine resources
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc This module provides a Webmachine resource that lists the
+%%      URLs for other resources available on this host.
+%%
+%%      Links to Riak resources will be added to the Link header in
+%%      the form:
+%%```
+%%         <URL>; rel="RESOURCE_NAME"
+%%'''
+%%      HTML output of this resource is a list of link tags like:
+%%```
+%%         <a href="URL">RESOURCE_NAME</a>
+%%'''
+%%      JSON output of this resource in an object with elements like:
+%%```
+%%         "RESOURCE_NAME":"URL"
+%%'''
+-module(riak_api_wm_urlmap).
+-export([
+         init/1,
+         resource_exists/2,
+         content_types_provided/2,
+         to_html/2,
+         to_json/2
+        ]).
+
+-include_lib("webmachine/include/webmachine.hrl").
+
+init([]) ->
+    {ok, service_list()}.
+
+resource_exists(RD, Services) ->
+    {true, add_link_header(RD, Services), Services}.
+
+add_link_header(RD, Services) ->
+    wrq:set_resp_header(
+      "Link",
+      string:join([ ["<",Uri,">; rel=\"",Resource,"\""]
+                    || {Resource, Uri} <- Services ],
+                  ","),
+      RD).
+
+content_types_provided(RD, Services) ->
+    {[{"text/html", to_html},{"application/json", to_json}], RD, Services}.
+
+to_html(RD, Services) ->
+    {["<html><body><ul>",
+      [ ["<li><a href=\"", Uri, "\">", Resource, "</a></li>"]
+        || {Resource, Uri} <- Services ],
+      "</ul></body></html>"],
+     RD, Services}.
+
+to_json(RD, Services) ->
+    {mochijson:encode({struct, Services}), RD, Services}.
+
+service_list() ->
+    Dispatch = webmachine_router:get_routes(),
+    lists:usort(
+      [{atom_to_list(Resource), "/"++UriBase}
+       || {[UriBase|_], Resource, _} <- Dispatch]).


### PR DESCRIPTION
Generally,
    riak_core_web -> riak_api_web
    riak_core_wm_urlmap -> riak_api_wm_urlmap

... but with modifications:
- Listeners from riak_core_sup are now added in riak_api_sup.
- We are ignoring any `disable_http_nagle` setting. Nagle is off.
- Default SSL cert/key are scoped to the platform_etc_dir instead of
  the static "etc/".
- Formatted the listener names according to "SCHEME://IP:PORT". IPv6
  interfaces are surrounded with square brackets to conform with
  convention.
