### PR TITLE
Add swap/3 API

### DIFF
--- a/src/riak_api_pb_registrar.erl
+++ b/src/riak_api_pb_registrar.erl
@@ -41,6 +41,7 @@
          start_link/0,
          register/1,
          deregister/1,
+         swap/3,
          set_heir/1,
          services/0,
          lookup/1
@@ -83,6 +84,11 @@ deregister(Registrations) ->
             ok
     end.
 
+%% @doc Atomically swap currently registered module with `NewModule'.
+-spec swap(module(), pos_integer(), pos_integer()) -> ok | {error, Reason::term()}.
+swap(NewModule, MinCode, MaxCode) ->
+    gen_server:call(?SERVER, {swap, NewModule, MinCode, MaxCode}, infinity).
+
 %% @doc Sets the heir of the registrations table on behalf of the
 %%      helper process.
 %% @private
@@ -122,7 +128,11 @@ handle_call({register, Registrations}, _From, State) ->
     {reply, Reply, State};
 handle_call({deregister, Registrations}, _From, State) ->
     Reply = do_deregister(Registrations),
+    {reply, Reply, State};
+handle_call({swap, NewModule, MinCode, MaxCode}, _From, State) ->
+    Reply = do_swap(NewModule, MinCode, MaxCode),
     {reply, Reply, State}.
+
 
 handle_cast(_Msg, State) ->
     {noreply, State}.
@@ -174,6 +184,16 @@ do_register(Module, MinCode, MaxCode) ->
             {error, {already_registered, AlreadyClaimed}}
     end.
 
+do_swap(NewModule, MinCode, MaxCode) ->
+    CodeRange = lists:seq(MinCode, MaxCode),
+    Matching = lists:filter(fun is_registered/1, CodeRange),
+    case length(Matching) == length(CodeRange) of
+        true ->
+            ets:insert(?ETS_NAME, [{Code, NewModule} || Code <- CodeRange]),
+            riak_api_pb_sup:service_registered(NewModule);
+        false ->
+            {error, {range_not_registered, CodeRange}}
+    end.
 
 do_deregister([]) ->
     ok;

--- a/src/riak_api_pb_service.erl
+++ b/src/riak_api_pb_service.erl
@@ -167,7 +167,8 @@
          register/3,
          deregister/1,
          deregister/2,
-         deregister/3]).
+         deregister/3,
+         swap/3]).
 
 -type registration() :: {Service::module(), MinCode::pos_integer(), MaxCode::pos_integer()}.
 
@@ -230,3 +231,10 @@ deregister(Module, Code) ->
 -spec deregister(Module::module(), MinCode::pos_integer(), MaxCode::pos_integer()) -> ok | {error, Err::term()}.
 deregister(Module, MinCode, MaxCode) ->
     deregister([{Module, MinCode, MaxCode}]).
+
+%% @doc Perform an atomic swap of current module to `NewModule' for
+%% the given code range.  The code range must exactly match an
+%% existing range.  Otherwise an error is returned.
+-spec swap(module(), pos_integer(), pos_integer()) -> ok | {error, Err::term()}.
+swap(NewModule, MinCode, MaxCode) ->
+    riak_api_pb_registrar:swap(NewModule, MinCode, MaxCode).

--- a/test/pb_dummy_svc.erl
+++ b/test/pb_dummy_svc.erl
@@ -1,0 +1,27 @@
+-module(pb_dummy_svc).
+-behaviour(riak_api_pb_service).
+-export([init/0,
+         decode/2,
+         encode/1,
+         process/2,
+         process_stream/3]).
+
+init() ->
+    undefined.
+
+decode(101, <<>>) ->
+    {ok, dummyreq};
+decode(_,_) ->
+    {error, unknown_message}.
+
+encode(ok) ->
+    {ok, <<102,$s,$w,$a,$p>>};
+encode(_) ->
+    error.
+
+process(dummyreq, State) ->
+    {reply, ok, State}.
+
+process_stream(_, _, State) ->
+    {ignore, State}.
+

--- a/test/pb_service_test.erl
+++ b/test/pb_service_test.erl
@@ -226,6 +226,20 @@ deregister_during_shutdown_test_() ->
             end)
      }.
 
+swap_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     ?_test(begin
+                ?assertEqual([102|<<"ok">>], request(101, <<>>)),
+                R1 = riak_api_pb_service:swap(pb_dummy_svc, 99, 110),
+                ?assertMatch({error, _}, R1),
+                R2 = riak_api_pb_service:swap(pb_dummy_svc, 99, 109),
+                ?assertEqual(ok, R2),
+                ?assertEqual([102|<<"swap">>], request(101, <<>>))
+            end)}.
+
+
 wait_for_port() ->
     wait_for_port(10000).
 


### PR DESCRIPTION
Add ability to atomically swap the callback module for a given code
range.  The exact code range must already be registered or an error
tuple is returned.

NOTE: This is needed for migrating from Riak Search to Yokozuna, see basho/yokozuna#20.
