### PR TITLE
Add security to Riak

### DIFF
--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -161,8 +161,8 @@ wait_for_auth({msg, MsgCode, MsgData}, State=#state{socket=Socket}) ->
             AuthReq = riak_pb_codec:decode(MsgCode, MsgData),
             lager:info("user authed with ~p/~p", [AuthReq#rpbauthreq.user,
                                                   AuthReq#rpbauthreq.password]),
-            User = binary_to_list(AuthReq#rpbauthreq.user),
-            Password = binary_to_list(AuthReq#rpbauthreq.password),
+            User = AuthReq#rpbauthreq.user,
+            Password = AuthReq#rpbauthreq.password,
             {PeerIP, _PeerPort} = State#state.peername,
             case riak_core_security:authenticate(User, Password, [{ip,
                                                                    PeerIP},
@@ -219,7 +219,7 @@ connected({msg, MsgCode, MsgData}, State=#state{states=ServiceStates}) ->
                                 process_message(Service, Message, ServiceState, State);
                             SecCtx ->
                                 case riak_core_security:check_permission(
-                                        Permission, binary_to_list(Bucket), SecCtx) of
+                                        Permission, Bucket, SecCtx) of
                                     {true, NewCtx} ->
                                         ServiceState = orddict:fetch(Service, ServiceStates),
                                         process_message(Service, Message,

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -161,8 +161,6 @@ wait_for_auth({msg, MsgCode, MsgData}, State=#state{socket=Socket,
         MsgCode ->
             %% got AUTH message, try to validate credentials
             AuthReq = riak_pb_codec:decode(MsgCode, MsgData),
-            lager:info("user authed with ~p/~p", [AuthReq#rpbauthreq.user,
-                                                  AuthReq#rpbauthreq.password]),
             User = AuthReq#rpbauthreq.user,
             Password = AuthReq#rpbauthreq.password,
             {PeerIP, _PeerPort} = State#state.peername,
@@ -171,7 +169,7 @@ wait_for_auth({msg, MsgCode, MsgData}, State=#state{socket=Socket,
                                                                   {common_name,
                                                                    State#state.common_name}]) of
                 {ok, SecurityContext} ->
-                    lager:info("authentication for ~p from ~p succeeded",
+                    lager:debug("authentication for ~p from ~p succeeded",
                                [User, PeerIP]),
                     AuthResp = riak_pb_codec:msg_code(rpbauthresp),
                     Transport:send(Socket, <<1:32/unsigned-big, AuthResp:8>>),

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -144,7 +144,7 @@ wait_for_tls({msg, MsgCode, _MsgData}, State=#state{socket=Socket,
             end;
         _ ->
             lager:info("got msgcode ~p", [MsgCode]),
-            State1 = send_error_and_flush("Security is enabled, please STARTLS first",
+            State1 = send_error_and_flush("Security is enabled, please STARTTLS first",
                                  State),
             {next_state, wait_for_tls, State1}
     end;

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -94,7 +94,7 @@ wait_for_socket({set_socket, Socket}, _From, State=#state{transport=Transport}) 
     Transport:setopts(Socket, [{active, once}]),
     %% check if security is enabled, if it is wait for TLS, otherwise go
     %% straight into connected state
-    case app_helper:get_env(riak_core, security, false) of
+    case riak_core_security:is_enabled() of
         true ->
             {reply, ok, wait_for_tls, State#state{socket=Socket,
                                                   peername=PeerInfo}};

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -213,22 +213,20 @@ connected({msg, MsgCode, MsgData}, State=#state{states=ServiceStates}) ->
         %% First find the appropriate service module to dispatch
         NewState = case riak_api_pb_registrar:lookup(MsgCode) of
             {ok, Service} ->
+                ServiceState = orddict:fetch(Service, ServiceStates),
                 %% Decode the message according to the service
                 case Service:decode(MsgCode, MsgData) of
                     {ok, Message} ->
                         %% Process the message
-                        ServiceState = orddict:fetch(Service, ServiceStates),
                         process_message(Service, Message, ServiceState, State);
                     {ok, Message, Permissions} ->
                         case State#state.security of
                             undefined ->
-                                ServiceState = orddict:fetch(Service, ServiceStates),
                                 process_message(Service, Message, ServiceState, State);
                             SecCtx ->
                                 case riak_core_security:check_permissions(
                                         Permissions, SecCtx) of
                                     {true, NewCtx} ->
-                                        ServiceState = orddict:fetch(Service, ServiceStates),
                                         process_message(Service, Message,
                                                         ServiceState,
                                                         State#state{security=NewCtx});

--- a/src/riak_api_web_security.erl
+++ b/src/riak_api_web_security.erl
@@ -1,0 +1,40 @@
+-module(riak_api_web_security).
+
+-export([is_authorized/1]).
+
+%% @doc Some security helper functions for Riak API endpoints
+
+%% @doc Check if the user is authorized
+-spec is_authorized(any()) -> {true, any()} | false | insecure.
+is_authorized(ReqData) ->
+    case riak_core_security:is_enabled() of
+        true ->
+            Scheme = wrq:scheme(ReqData),
+            case Scheme == https of
+                true ->
+                    case wrq:get_req_header("Authorization", ReqData) of
+                        "Basic " ++ Base64 ->
+                            UserPass = base64:decode_to_string(Base64),
+                            [User, Pass] = [list_to_binary(X) || X <-
+                                                                 string:tokens(UserPass, ":")],
+                            {ok, Peer} = inet_parse:address(wrq:peer(ReqData)),
+                            case riak_core_security:authenticate(User, Pass,
+                                    [{ip, Peer}])
+                                of
+                                {ok, Sec} ->
+                                    {true, Sec};
+                                {error, _} ->
+                                    false
+                            end;
+                        _ ->
+                            false
+                    end;
+                false ->
+                    %% security is enabled, but they're connecting over HTTP.
+                    %% which means if they authed, the credentials would be in
+                    %% plaintext
+                    insecure
+            end;
+        false ->
+            {true, undefined} %% no security context
+    end.

--- a/src/riak_core_pb_bucket_type.erl
+++ b/src/riak_core_pb_bucket_type.erl
@@ -48,7 +48,16 @@ init() ->
 
 %% @doc decode/2 callback. Decodes an incoming message.
 decode(Code, Bin) when Code == 31; Code == 32; Code == 33 ->
-    {ok, riak_pb_codec:decode(Code, Bin)}.
+    Msg = riak_pb_codec:decode(Code, Bin),
+    case Msg of
+        #rpbgetbuckettypereq{type=T} ->
+            {ok, Msg, {"riak_core.get_bucket_type", T}};
+        #rpbsetbuckettypereq{type=T} ->
+            {ok, Msg, {"riak_core.set_bucket_type", T}};
+        #rpbresetbuckettypereq{type=T} ->
+            %% reset is a fancy set
+            {ok, Msg, {"riak_core.set_bucket_type", T}}
+    end.
 
 %% @doc encode/1 callback. Encodes an outgoing response message.
 encode(Message) ->


### PR DESCRIPTION
This PR adds security to the PB API as well as implementing security for the API endpoints riak_api exposes for riak_core.

The PB API now has a sort of pre-session handshake that is done, as illustrated by the flow-chart below:

![protobuffs_security](https://f.cloud.github.com/assets/86412/1152391/1464b968-1f0c-11e3-88a9-f49ced35e9d7.png)

To facilitate this, riak_api_pb_server was rewritten to be a gen_fsm.

See also basho/riak#355
