### PR TITLE
Moved riak_api bits of riak.schema, and added unit tests

### DIFF
--- a/priv/riak_api.schema
+++ b/priv/riak_api.schema
@@ -1,0 +1,59 @@
+%% HTTP Listeners
+%% @doc listener.http.<name> is an IP address and TCP port that the Riak
+%% HTTP interface will bind.
+{mapping, "listener.http.$name", "riak_api.http", [
+  {default, {"{{web_ip}}",{{web_port}} }},
+  {datatype, ip},
+  {include_default, "internal"}
+]}.
+
+{ translation,
+  "riak_api.http",
+    fun(Conf) ->
+        HTTP = cuttlefish_util:filter_by_variable_starts_with("listener.http", Conf),
+        [ IP || {_, IP} <- HTTP]
+    end
+}.
+
+%% protobuf Listeners
+%% @doc listener.protobuf.<name> is an IP address and TCP port that the Riak 
+%% Protocol Buffers interface will bind.
+{mapping, "listener.protobuf.$name", "riak_api.pb", [
+  {default, "{{pb_ip}}:{{pb_port}}"},
+  {datatype, ip},
+  {include_default, "internal"}
+]}.
+
+{ translation,
+  "riak_api.pb",
+    fun(Conf) ->
+        PB = cuttlefish_util:filter_by_variable_starts_with("listener.protobuf", Conf),
+        [ IP || {_, IP} <- PB]
+    end
+}.
+
+%% @doc pb_backlog is the maximum length to which the queue of pending
+%% connections may grow. If set, it must be an integer >= 0.
+%% By default the value is 5. If you anticipate a huge number of
+%% connections being initialised *simultaneously*, set this number
+%% higher.
+{mapping, "protobuf.backlog", "riak_api.pb_backlog", [
+  {datatype, integer},
+  {commented, 64}
+]}.
+
+%% @doc listener.https.<name> is an IP address and TCP port that the Riak
+%% HTTPS interface will bind.
+{mapping, "listener.https.$name", "riak_api.https", [
+  {commented, {"{{web_ip}}",{{web_port}} }},
+  {datatype, ip},
+  {include_default, "internal"}
+]}.
+
+{ translation,
+  "riak_api.https",
+    fun(Conf) ->
+        HTTPS = cuttlefish_util:filter_by_variable_starts_with("listener.https", Conf),
+        [ IP || {_, IP} <- HTTPS]
+    end
+}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,6 @@
 {deps, [
         {riak_pb, "2.0.0.7", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.7"}}},
         {webmachine, "1.10.4", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.4p2"}}},
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}}
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}},
+        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
         ]}.

--- a/test/riak_api_schema_tests.erl
+++ b/test/riak_api_schema_tests.erl
@@ -1,0 +1,48 @@
+-module(riak_api_schema_tests).
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+
+%% basic schema test will check to make sure that all defaults from the schema
+%% make it into the generated app.config
+basic_schema_test() ->
+     %% The defaults are defined in ../priv/riak_api.schema. it is the file under test. 
+    Config = cuttlefish_unit:generate_templated_config("../priv/riak_api.schema", [], context()),
+
+    cuttlefish_unit:assert_config(Config, "riak_api.http", [{"127.0.0.1", 8098}]),
+    cuttlefish_unit:assert_config(Config, "riak_api.pb", [{"127.0.0.1", 8087}]),
+    cuttlefish_unit:assert_config(Config, "riak_api.https", undefined),
+    cuttlefish_unit:assert_config(Config, "protobuf.backlog", undefined),
+    ok.
+
+override_schema_test() ->
+    %% Conf represents the riak.conf file that would be read in by cuttlefish.
+    %% this proplists is what would be output by the conf_parse module
+    Conf = [
+        {["listener", "http", "internal"], "127.0.0.2:8000"},
+        {["listener", "http", "external"], "127.0.0.3:8000"},
+        {["listener", "protobuf", "internal"], "127.0.0.8:3000"},
+        {["listener", "protobuf", "external"], "127.0.0.9:3000"},
+        {["listener", "https", "internal"], "127.0.0.12:443"},
+        {["listener", "https", "external"], "127.0.0.13:443"},
+        {["protobuf", "backlog"], 64}
+    ],
+    Config = cuttlefish_unit:generate_templated_config("../priv/riak_api.schema", Conf, context()),
+
+
+    cuttlefish_unit:assert_config(Config, "riak_api.http", [{"127.0.0.3", 8000}, {"127.0.0.2", 8000}]),
+    cuttlefish_unit:assert_config(Config, "riak_api.pb", [{"127.0.0.9", 3000}, {"127.0.0.8", 3000}]),
+    cuttlefish_unit:assert_config(Config, "riak_api.https", [{"127.0.0.13", 443}, {"127.0.0.12", 443}]),
+    cuttlefish_unit:assert_config(Config, "riak_api.pb_backlog", 64),
+    ok.
+
+%% this context() represents the substitution variables that rebar will use during the build process.
+%% riak_core's schema file is written with some {{mustache_vars}} for substitution during packaging
+%% cuttlefish doesn't have a great time parsing those, so we perform the substitutions first, because
+%% that's how it would work in real life.
+context() ->
+    [
+        {web_ip, "127.0.0.1"},
+        {web_port, 8098},
+        {pb_ip, "127.0.0.1"},
+        {pb_port, 8087}
+    ].


### PR DESCRIPTION
Requires https://github.com/basho/cuttlefish/pull/43 to work, so make sure you point your deps/cuttlefish at jd-test-tools. Please review both PRs together. 

Here you'll find all the api bits of the schema, and a unit test that validates them.
