### PR TITLE
Fix late registrations: riak_api_pb_server is no longer a gen_server

### DIFF
--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -36,7 +36,7 @@
 -behaviour(gen_fsm).
 
 %% API
--export([start_link/0, set_socket/2]).
+-export([start_link/0, set_socket/2, service_registered/2]).
 
 %% States
 -export([wait_for_socket/2, wait_for_socket/3, wait_for_tls/2, wait_for_tls/3,
@@ -74,6 +74,11 @@ start_link() ->
 -spec set_socket(pid(), port()) -> ok.
 set_socket(Pid, Socket) ->
     gen_fsm:sync_send_event(Pid, {set_socket, Socket}, infinity).
+
+%% @doc Notifies the server process of a newly registered PB service.
+-spec service_registered(pid(), module()) -> ok.
+service_registered(Pid, Mod) ->
+    gen_fsm:send_all_state_event(Pid, {registered, Mod}).
 
 %% @doc The gen_server init/1 callback, initializes the
 %% riak_api_pb_server.

--- a/src/riak_api_pb_sup.erl
+++ b/src/riak_api_pb_sup.erl
@@ -40,7 +40,7 @@ service_registered(Mod) ->
         undefined ->
             ok;
         _ ->
-            [ gen_server:cast(Pid, {registered, Mod}) ||
+            [ riak_api_pb_server:service_registered(Pid, Mod) ||
                 {_,Pid,_,_} <- supervisor:which_children(?MODULE) ],
             ok
     end.


### PR DESCRIPTION
Use `gen_fsm:send_all_state_event/2` instead of `gen_server:cast/2`.
