### PR TITLE
Integrate the Exometer metrics package

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [
         {riak_pb, "2.0.0.16", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.16"}}},
         {webmachine, "1.10.5", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.5"}}},
-        {riak_core, ".*", {git, "git@github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
+        {riak_core, ".*", {git, "git://github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
         ]}.
 
 {xref_checks, [undefined_function_calls]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [
         {riak_pb, "2.0.0.16", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.16"}}},
         {webmachine, "1.10.5", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.5"}}},
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}}
+        {riak_core, ".*", {git, "git://github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
         ]}.
 
 {xref_checks, [undefined_function_calls]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [
         {riak_pb, "2.0.0.16", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.16"}}},
         {webmachine, "1.10.5", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.5"}}},
-        {riak_core, ".*", {git, "git://github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
+        {riak_core, ".*", {git, "git@github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
         ]}.
 
 {xref_checks, [undefined_function_calls]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [
         {riak_pb, "2.0.0.16", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.16"}}},
         {webmachine, "1.10.5", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.5"}}},
-        {riak_core, ".*", {git, "git@github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "feuerlabs-exometer"}}}
         ]}.
 
 {xref_checks, [undefined_function_calls]}.

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -28,7 +28,7 @@
          produce_stats/0,
          update/1,
          stats/0,
-         active_pb_connects/1]).
+         active_pb_connects/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -45,13 +45,15 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    riak_core_stat:register_stats(?APP, stats()).
+    [(catch exometer_entry:delete([?APP, Name])) || {Name, _Type} <- stats()],
+    [register_stat(stat_name(Stat), Type) || {Stat, Type} <- stats()],
+    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
 
 %% @doc Return current aggregation of all stats.
 -spec get_stats() -> proplists:proplist().
 get_stats() ->
     case riak_core_stat_cache:get_stats(?APP) of
-        {ok, Stats} ->
+        {ok, Stats, _TS} ->
             Stats;
         Error -> Error
     end.
@@ -89,7 +91,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Update the given `Stat'.
 -spec update1(term()) -> ok.
 update1(pbc_connect) ->
-    exometer:update([?APP, pbc_connects], 1).
+    exometer_entry:update([?APP, pbc_connects], 1).
 
 %% -------------------------------------------------------------------
 %% Private
@@ -101,7 +103,27 @@ stats() ->
       {function, ?MODULE, active_pb_connects}}
     ].
 
-active_pb_connects(_) ->
+%% stat_name(Name) when is_list(Name) ->
+%%     list_to_tuple([?APP] ++ Name);
+%% stat_name(Name) when is_atom(Name) ->
+%%     {?APP, Name}.
+stat_name(Name) ->
+    [?APP | stat_name_(Name)].
+
+stat_name_(Name) when is_tuple(Name) ->
+    tuple_to_list(Name);
+stat_name_(Name) when is_list(Name) ->
+    Name;
+stat_name_(Name) when is_atom(Name) ->
+    [Name].
+
+
+register_stat(Name, spiral) ->
+    exometer_entry:new(Name, spiral);
+register_stat(Name, {function, _Module, _Function}=Fun) ->
+    exometer_entry:new(Name, Fun).
+
+active_pb_connects() ->
     %% riak_api_pb_sup will not be running when there are no listeners
     %% defined.
     case erlang:whereis(riak_api_pb_sup) of

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -105,6 +105,7 @@ active_pb_connects(_) ->
     %% riak_api_pb_sup will not be running when there are no listeners
     %% defined.
     case erlang:whereis(riak_api_pb_sup) of
-        undefined -> 0;
-        _ -> proplists:get_value(active, supervisor:count_children(riak_api_pb_sup))
+        undefined -> [{value, 0}];
+        _ ->
+	    [{value, proplists:get_value(active, supervisor:count_children(riak_api_pb_sup), 0)}]
     end.

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -45,9 +45,7 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    [(catch exometer_entry:delete([?APP, Name])) || {Name, _Type} <- stats()],
-    [register_stat(stat_name(Stat), Type) || {Stat, Type} <- stats()],
-    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
+    riak_core_stat:register_stats(?APP, stats()).
 
 %% @doc Return current aggregation of all stats.
 -spec get_stats() -> proplists:proplist().
@@ -91,7 +89,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Update the given `Stat'.
 -spec update1(term()) -> ok.
 update1(pbc_connect) ->
-    exometer_entry:update([?APP, pbc_connects], 1).
+    exometer:update([?APP, pbc_connects], 1).
 
 %% -------------------------------------------------------------------
 %% Private
@@ -103,27 +101,7 @@ stats() ->
       {function, ?MODULE, active_pb_connects}}
     ].
 
-%% stat_name(Name) when is_list(Name) ->
-%%     list_to_tuple([?APP] ++ Name);
-%% stat_name(Name) when is_atom(Name) ->
-%%     {?APP, Name}.
-stat_name(Name) ->
-    [?APP | stat_name_(Name)].
-
-stat_name_(Name) when is_tuple(Name) ->
-    tuple_to_list(Name);
-stat_name_(Name) when is_list(Name) ->
-    Name;
-stat_name_(Name) when is_atom(Name) ->
-    [Name].
-
-
-register_stat(Name, spiral) ->
-    exometer_entry:new(Name, spiral);
-register_stat(Name, {function, _Module, _Function}=Fun) ->
-    exometer_entry:new(Name, Fun).
-
-active_pb_connects() ->
+active_pb_connects(_) ->
     %% riak_api_pb_sup will not be running when there are no listeners
     %% defined.
     case erlang:whereis(riak_api_pb_sup) of

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -28,7 +28,7 @@
          produce_stats/0,
          update/1,
          stats/0,
-         active_pb_connects/0]).
+         active_pb_connects/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -45,15 +45,13 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    [(catch exometer_entry:delete([?APP, Name])) || {Name, _Type} <- stats()],
-    [register_stat(stat_name(Stat), Type) || {Stat, Type} <- stats()],
-    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
+    riak_core_stat:register_stats(?APP, stats()).
 
 %% @doc Return current aggregation of all stats.
 -spec get_stats() -> proplists:proplist().
 get_stats() ->
     case riak_core_stat_cache:get_stats(?APP) of
-        {ok, Stats, _TS} ->
+        {ok, Stats} ->
             Stats;
         Error -> Error
     end.
@@ -91,7 +89,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Update the given `Stat'.
 -spec update1(term()) -> ok.
 update1(pbc_connect) ->
-    exometer_entry:update([?APP, pbc_connects], 1).
+    exometer:update([?APP, pbc_connects], 1).
 
 %% -------------------------------------------------------------------
 %% Private
@@ -103,27 +101,7 @@ stats() ->
       {function, ?MODULE, active_pb_connects}}
     ].
 
-%% stat_name(Name) when is_list(Name) ->
-%%     list_to_tuple([?APP] ++ Name);
-%% stat_name(Name) when is_atom(Name) ->
-%%     {?APP, Name}.
-stat_name(Name) ->
-    [?APP | stat_name_(Name)].
-
-stat_name_(Name) when is_tuple(Name) ->
-    tuple_to_list(Name);
-stat_name_(Name) when is_list(Name) ->
-    Name;
-stat_name_(Name) when is_atom(Name) ->
-    [Name].
-
-
-register_stat(Name, spiral) ->
-    exometer_entry:new(Name, spiral);
-register_stat(Name, {function, _Module, _Function}=Fun) ->
-    exometer_entry:new(Name, Fun).
-
-active_pb_connects() ->
+active_pb_connects(_) ->
     %% riak_api_pb_sup will not be running when there are no listeners
     %% defined.
     case erlang:whereis(riak_api_pb_sup) of

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -45,7 +45,9 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    riak_core_stat:register_stats(?APP, stats()).
+    [(catch exometer_entry:delete([?APP, Name])) || {Name, _Type} <- stats()],
+    [register_stat(stat_name(Stat), Type) || {Stat, Type} <- stats()],
+    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
 
 %% @doc Return current aggregation of all stats.
 -spec get_stats() -> proplists:proplist().
@@ -89,7 +91,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Update the given `Stat'.
 -spec update1(term()) -> ok.
 update1(pbc_connect) ->
-    exometer:update([riak_core_stat:prefix(), ?APP, pbc_connects], 1).
+    exometer_entry:update([?APP, pbc_connects], 1).
 
 %% -------------------------------------------------------------------
 %% Private
@@ -98,8 +100,28 @@ stats() ->
     [
      {pbc_connects, spiral},
      {[pbc_connects, active],
-      {function, ?MODULE, active_pb_connects, [], value, [value]}}
+      {function, ?MODULE, active_pb_connects}}
     ].
+
+%% stat_name(Name) when is_list(Name) ->
+%%     list_to_tuple([?APP] ++ Name);
+%% stat_name(Name) when is_atom(Name) ->
+%%     {?APP, Name}.
+stat_name(Name) ->
+    [?APP | stat_name_(Name)].
+
+stat_name_(Name) when is_tuple(Name) ->
+    tuple_to_list(Name);
+stat_name_(Name) when is_list(Name) ->
+    Name;
+stat_name_(Name) when is_atom(Name) ->
+    [Name].
+
+
+register_stat(Name, spiral) ->
+    exometer_entry:new(Name, spiral);
+register_stat(Name, {function, _Module, _Function}=Fun) ->
+    exometer_entry:new(Name, Fun).
 
 active_pb_connects() ->
     %% riak_api_pb_sup will not be running when there are no listeners

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -45,8 +45,8 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    _ = [(catch folsom_metrics:delete_metric({?APP, Name})) || {Name, _Type} <- stats()],
-    _ = [register_stat(stat_name(Stat), Type) || {Stat, Type} <- stats()],
+    [(catch exometer_entry:delete([?APP, Name])) || {Name, _Type} <- stats()],
+    [register_stat(stat_name(Stat), Type) || {Stat, Type} <- stats()],
     riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
 
 %% @doc Return current aggregation of all stats.
@@ -91,7 +91,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Update the given `Stat'.
 -spec update1(term()) -> ok.
 update1(pbc_connect) ->
-    folsom_metrics:notify_existing_metric({?APP, pbc_connects}, 1, spiral).
+    exometer_entry:update([?APP, pbc_connects], 1).
 
 %% -------------------------------------------------------------------
 %% Private
@@ -103,16 +103,25 @@ stats() ->
       {function, ?MODULE, active_pb_connects}}
     ].
 
-stat_name(Name) when is_list(Name) ->
-    list_to_tuple([?APP] ++ Name);
-stat_name(Name) when is_atom(Name) ->
-    {?APP, Name}.
+%% stat_name(Name) when is_list(Name) ->
+%%     list_to_tuple([?APP] ++ Name);
+%% stat_name(Name) when is_atom(Name) ->
+%%     {?APP, Name}.
+stat_name(Name) ->
+    [?APP | stat_name_(Name)].
+
+stat_name_(Name) when is_tuple(Name) ->
+    tuple_to_list(Name);
+stat_name_(Name) when is_list(Name) ->
+    Name;
+stat_name_(Name) when is_atom(Name) ->
+    [Name].
+
 
 register_stat(Name, spiral) ->
-    folsom_metrics:new_spiral(Name);
+    exometer_entry:new(Name, spiral);
 register_stat(Name, {function, _Module, _Function}=Fun) ->
-    ok = folsom_metrics:new_gauge(Name),
-    folsom_metrics:notify({Name, Fun}).
+    exometer_entry:new(Name, Fun).
 
 active_pb_connects() ->
     %% riak_api_pb_sup will not be running when there are no listeners


### PR DESCRIPTION
This PR is part of a set of PRs aimed at integrating the [Exometer](https://github.com/Feuerlabs/exometer) metrics package into Riak.

(From basho/riak_core#465)

From our measurements so far, Exometer offers both better throughput and lower footprint than the previous metrics management, and at the same time offers more flexible and uniform handling and better extensibility.

In addition to maintaining the console command `riak-admin status` and the HTTP JSON report (which aim to be backwards-compatible), a new console command, `riak-admin stat <cmd>` has been added, for selective reporting of statistics as well as some management (ability to enable/disable metrics on the fly).

Other noteworthy changes:
- Exometer entry names are always lists. In riak, only atoms and numbers should be used as list elements.
- A top-level 'prefix' (default: `riak`) has been added, in order to differentiate between stats from different riak-style products (e.g. when reporting stats to collectd). The function `riak_core_stat:prefix()` is generated as a constant expression through the parse transform `riak_core_stat_xform`, which in its turn checks the OS env variable `RIAK_CORE_STAT_PREFIX`. A typical entry would thus be e.g. `[riak,riak_kv,node,gets,siblings]`.
- Internally in riak, stats are referred to symbolically using the same (tuple-based) names as before. These often refer to more than one low-level metric, so it seemed reasonable to keep this naming scheme.
- Exometer provides similar functionality as 'sidejob' and the riak_core stat cache, so these are no longer used for stats management (although sidejob still maintains some stats on its own, which are accessible via Exometer). Other apps still register with `riak_core_stat`, but need not provide callbacks in other to query the stats. The query style of exometer is the same as that of riak_core_stat.
