### PR TITLE
Honor configured cipher suites and add an option to honor the order

### DIFF
--- a/priv/riak_api.schema
+++ b/priv/riak_api.schema
@@ -80,3 +80,26 @@
         [ IP || {_, IP} <- HTTPS]
     end
 }.
+
+%% @doc Whether or not to honor the order in which the server lists its
+%% preferred ciphers.
+{mapping, "honor_cipher_order", "riak_api.honor_cipher_order", [
+  {datatype, {enum, [on, off]}},
+  {default, on}
+]}.
+
+{translation,
+  "riak_api.honor_cipher_order",
+   fun(Conf) ->
+     OTPVer = erlang:system_info(otp_release),
+     CipherOrder = cuttlefish_util:conf_get_value("honor_cipher_order", Conf),
+     %% This is only available, as of December 2013, in basho patched R16B02,
+     %% so disable it if the VM is not patched by basho. This can be revised
+     %% for R17, when this patch is expected to be present mainline.
+     case {CipherOrder, string:str(OTPVer, "basho")} of
+       {_, 0} -> false;
+       {on, _} -> true;
+       {off, _} -> false
+     end
+   end
+}.

--- a/priv/riak_api.schema
+++ b/priv/riak_api.schema
@@ -103,3 +103,72 @@
      end
    end
 }.
+
+%% @doc Determine which SSL/TLS versions are allowed. By default only TLS 1.2
+%% is allowed, but other versions can be enabled if clients don't support the
+%% latest TLS standard. It is *strongly* recommended that SSLv3 is not enabled
+%% unless absolutely necessary. More than one protocol can be enabled at once.
+{mapping, "tls_protocols.sslv3", "riak_api.tls_protocols", [
+  {datatype, {enum, [on, off]}},
+  {default, off}
+]}.
+
+{mapping, "tls_protocols.tlsv1", "riak_api.tls_protocols", [
+  {datatype, {enum, [on, off]}},
+  {default, off}
+]}.
+
+{mapping, "tls_protocols.tlsv1.1", "riak_api.tls_protocols", [
+  {datatype, {enum, [on, off]}},
+  {default, off}
+]}.
+
+{mapping, "tls_protocols.tlsv1.2", "riak_api.tls_protocols", [
+  {datatype, {enum, [on, off]}},
+  {default, on}
+]}.
+
+{ translation,
+  "riak_api.tls_protocols",
+    fun(Conf) ->
+        Protocols = cuttlefish_util:filter_by_variable_starts_with("tls_protocols", Conf),
+        [begin
+             case Key of
+                 ["tls_protocols","sslv3"] ->
+                     sslv3;
+                 ["tls_protocols","tlsv1"] ->
+                     tlsv1;
+                 ["tls_protocols","tlsv1", "1"] ->
+                     'tlsv1.1';
+                 ["tls_protocols","tlsv1", "2"] ->
+                     'tlsv1.2'
+             end
+         end
+         || {Key, Value} <- Protocols, Value == on]
+    end
+}.
+
+%% @doc Whether to check the CRL of a client certificate. This defaults to
+%% true but some CAs may not maintain or define a CRL, so this can be disabled
+%% if no CRL is available.
+{mapping, "check_crl", "riak_api.check_crl", [
+  {datatype, {enum, [on, off]}},
+  {default, on}
+]}.
+
+{translation,
+  "riak_api.check_crl",
+   fun(Conf) ->
+     OTPVer = erlang:system_info(otp_release),
+     CheckCRL = cuttlefish_util:conf_get_value("check_crl", Conf),
+     %% CRL checking is broken in mainline OTP as of R16B02, so Riak will ship
+     %% with a patched SSL/public_key to fix it. This means that we don't want
+     %% to pass this option to a vanilla OTP.
+     case {CheckCRL, string:str(OTPVer, "basho")} of
+       {_, 0} -> false;
+       {on, _} -> true;
+       {off, _} -> false
+     end
+   end
+}.
+

--- a/priv/riak_api.schema
+++ b/priv/riak_api.schema
@@ -96,6 +96,8 @@
      %% This is only available, as of December 2013, in basho patched R16B02,
      %% so disable it if the VM is not patched by basho. This can be revised
      %% for R17, when this patch is expected to be present mainline.
+     %% The basho patched OTP can be found at:
+     %% https://github.com/basho/otp/tree/OTP_R16B02_basho3
      case {CipherOrder, string:str(OTPVer, "basho")} of
        {_, 0} -> false;
        {on, _} -> true;
@@ -113,16 +115,20 @@
   {default, off}
 ]}.
 
+%% @see tls_protocols.sslv3
 {mapping, "tls_protocols.tlsv1", "riak_api.tls_protocols", [
   {datatype, {enum, [on, off]}},
   {default, off}
 ]}.
 
+
+%% @see tls_protocols.sslv3
 {mapping, "tls_protocols.tlsv1.1", "riak_api.tls_protocols", [
   {datatype, {enum, [on, off]}},
   {default, off}
 ]}.
 
+%% @see tls_protocols.sslv3
 {mapping, "tls_protocols.tlsv1.2", "riak_api.tls_protocols", [
   {datatype, {enum, [on, off]}},
   {default, on}
@@ -164,6 +170,8 @@
      %% CRL checking is broken in mainline OTP as of R16B02, so Riak will ship
      %% with a patched SSL/public_key to fix it. This means that we don't want
      %% to pass this option to a vanilla OTP.
+     %% The basho patched OTP can be found at:
+     %% https://github.com/basho/otp/tree/OTP_R16B02_basho3
      case {CheckCRL, string:str(OTPVer, "basho")} of
        {_, 0} -> false;
        {on, _} -> true;

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -120,12 +120,15 @@ wait_for_tls({msg, MsgCode, _MsgData}, State=#state{socket=Socket,
             %% now do the SSL handshake
             CACerts = riak_core_ssl_util:load_certs(app_helper:get_env(riak_api,
                                                                        cacertfile)),
+            {Ciphers, _} =
+                riak_core_ssl_util:parse_ciphers(riak_core_security:get_ciphers()),
             case ssl:ssl_accept(Socket, [{certfile,
                                           app_helper:get_env(riak_api,
                                                                        certfile)},
                                          {keyfile, app_helper:get_env(riak_api,
                                                                       keyfile)},
                                          {cacerts, CACerts},
+                                         {ciphers, Ciphers},
                                          %% force peer validation, even though
                                          %% we don't care if the peer doesn't
                                          %% send a certificate

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -136,7 +136,12 @@ wait_for_tls({msg, MsgCode, _MsgData}, State=#state{socket=Socket,
                                          {verify_fun, {fun validate_function/3,
                                                        {CACerts, []}}},
                                          {reuse_sessions, false} %% required!
-                                        ]) of
+                                        ] ++
+                                        %% conditionally include the honor cipher order, don't pass it if it
+                                        %% disabled because it will crash unpatched OTP
+                                        [{honor_cipher_order, true} ||
+                                         app_helper:get_env(riak_api, honor_cipher_order, false) ]
+                               ) of
                 {ok, NewSocket} ->
                     CommonName = case ssl:peercert(NewSocket) of
                         {ok, Cert} ->

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -140,11 +140,15 @@ wait_for_tls({msg, MsgCode, _MsgData}, State=#state{socket=Socket,
                                          {reuse_sessions, false} %% required!
                                         ] ++
                                         %% conditionally include the honor cipher order, don't pass it if it
-                                        %% disabled because it will crash unpatched OTP
+                                        %% disabled because it will crash any
+                                        %% OTP installs that lack the patch to
+                                        %% implement honor_cipher_order
                                         [{honor_cipher_order, true} ||
                                          app_helper:get_env(riak_api,
                                                             honor_cipher_order,
                                                             false) ] ++
+                                        %% if we're validating CRLs, define a
+                                        %% verify_fun for them.
                                         [{verify_fun, {fun validate_function/3,
                                                        {CACerts, []}}} ||
                                          app_helper:get_env(riak_api,

--- a/src/riak_api_web.erl
+++ b/src/riak_api_web.erl
@@ -62,6 +62,8 @@ spec_from_binding(http, Name, {Ip, Port}) ->
 
 spec_from_binding(https, Name, {Ip, Port}) ->
     Etc = app_helper:get_env(riak_core, platform_etc_dir, "etc"),
+    {Ciphers, _} =
+        riak_core_ssl_util:parse_ciphers(riak_core_security:get_ciphers()),
     SslOpts = app_helper:get_env(riak_core, ssl,
                                  [{certfile, filename:join(Etc, "cert.pem")},
                                   {keyfile, filename:join(Etc, "key.pem")}]),
@@ -69,7 +71,7 @@ spec_from_binding(https, Name, {Ip, Port}) ->
                    {ip, Ip},
                    {port, Port},
                    {ssl, true},
-                   {ssl_opts, SslOpts},
+                   {ssl_opts, SslOpts ++ [{ciphers, Ciphers}]},
                    {nodelay, true}],
                   common_config()).
 

--- a/src/riak_api_web.erl
+++ b/src/riak_api_web.erl
@@ -66,12 +66,18 @@ spec_from_binding(https, Name, {Ip, Port}) ->
         riak_core_ssl_util:parse_ciphers(riak_core_security:get_ciphers()),
     SslOpts = app_helper:get_env(riak_core, ssl,
                                  [{certfile, filename:join(Etc, "cert.pem")},
-                                  {keyfile, filename:join(Etc, "key.pem")}]),
+                                  {keyfile, filename:join(Etc, "key.pem")}]) 
+        %% conditionally include the honor cipher order, don't pass it if it
+        %% disabled because it will crash unpatched OTP
+        ++ [{honor_cipher_order, true} ||
+            app_helper:get_env(riak_api, honor_cipher_order, false) ]
+        ++ [{ciphers, Ciphers}],
+
     lists:flatten([{name, Name},
                    {ip, Ip},
                    {port, Port},
                    {ssl, true},
-                   {ssl_opts, SslOpts ++ [{ciphers, Ciphers}]},
+                   {ssl_opts, SslOpts},
                    {nodelay, true}],
                   common_config()).
 

--- a/src/riak_api_web.erl
+++ b/src/riak_api_web.erl
@@ -68,7 +68,8 @@ spec_from_binding(https, Name, {Ip, Port}) ->
                                  [{certfile, filename:join(Etc, "cert.pem")},
                                   {keyfile, filename:join(Etc, "key.pem")}]) 
         %% Conditionally include the honor cipher order, don't pass it if it
-        %% disabled because it will crash unpatched OTP
+        %% disabled because it will crash any OTP installs that lack the patch
+        %% to implement honor_cipher_order.
         ++ [{honor_cipher_order, true} ||
             app_helper:get_env(riak_api, honor_cipher_order, false) ]
         ++ [{ciphers, Ciphers},

--- a/src/riak_api_web.erl
+++ b/src/riak_api_web.erl
@@ -67,11 +67,16 @@ spec_from_binding(https, Name, {Ip, Port}) ->
     SslOpts = app_helper:get_env(riak_core, ssl,
                                  [{certfile, filename:join(Etc, "cert.pem")},
                                   {keyfile, filename:join(Etc, "key.pem")}]) 
-        %% conditionally include the honor cipher order, don't pass it if it
+        %% Conditionally include the honor cipher order, don't pass it if it
         %% disabled because it will crash unpatched OTP
         ++ [{honor_cipher_order, true} ||
             app_helper:get_env(riak_api, honor_cipher_order, false) ]
-        ++ [{ciphers, Ciphers}],
+        ++ [{ciphers, Ciphers},
+            {versions,
+             app_helper:get_env(riak_api,
+                                tls_protocols,
+                                ['tlsv1.2'])}
+           ],
 
     lists:flatten([{name, Name},
                    {ip, Ip},


### PR DESCRIPTION
In additional to using the cipher suites configured in riak_core, you can also tell OTP to prefer the _order_ in which the cipher suite is listed in Riak, over any client preferences. This is more secure as it allows the server to order the ciphers such that it can put the ciphers with the attributes it values the most at the top of the list, but list others for compatability.

This new option, as it is only available in a patched OTP, can only be passed to the SSL api if it is being enabled. To avoid crashing Riak built with unpatched VMs, cuttlefish will automatically switch this option off on non-patched VMs.

See also basho/riak_core#469
