### PR TITLE
Feuerlabs stat combo

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,5 @@
 {deps, [
         {riak_pb, "2.0.0.10", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.10"}}},
         {webmachine, "1.10.5", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.5"}}},
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "feuerlabs-exometer"}}}
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "feuerlabs-stat-combo"}}}
         ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,5 @@
 {deps, [
         {riak_pb, "2.0.0.8", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.8"}}},
         {webmachine, "1.10.5", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.5"}}},
-        {riak_core, ".*", {git, "git://github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
+        {riak_core, ".*", {git, "git@github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
         ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,5 @@
 {deps, [
         {riak_pb, "2.0.0.8", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.8"}}},
         {webmachine, "1.10.5", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.5"}}},
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}}
+        {riak_core, ".*", {git, "git://github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
         ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,5 @@
 {deps, [
         {riak_pb, "2.0.0.10", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.10"}}},
         {webmachine, "1.10.5", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.5"}}},
-        {riak_core, ".*", {git, "git@github.com:Feuerlabs/riak_core.git", {branch, "uw-exometer-dev"}}}
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "feuerlabs-exometer"}}}
         ]}.

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -105,6 +105,7 @@ active_pb_connects(_) ->
     %% riak_api_pb_sup will not be running when there are no listeners
     %% defined.
     case erlang:whereis(riak_api_pb_sup) of
-        undefined -> 0;
-        _ -> proplists:get_value(active, supervisor:count_children(riak_api_pb_sup))
+        undefined -> [{value, 0}];
+        _ ->
+	    [{value, proplists:get_value(active, supervisor:count_children(riak_api_pb_sup), 0)}]
     end.

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -68,7 +68,7 @@ get_stats() ->
 
 get_stats_legacy() ->
     case riak_core_stat_cache:get_stats(?APP) of
-        {ok, Stats} ->
+        {ok, Stats, _TS} ->
             Stats;
         Error -> Error
     end.

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -28,7 +28,7 @@
          produce_stats/0,
          update/1,
          stats/0,
-         active_pb_connects/0]).
+         active_pb_connects/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -45,15 +45,13 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    [(catch exometer_entry:delete([?APP, Name])) || {Name, _Type} <- stats()],
-    [register_stat(stat_name(Stat), Type) || {Stat, Type} <- stats()],
-    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
+    riak_core_stat:register_stats(?APP, stats()).
 
 %% @doc Return current aggregation of all stats.
 -spec get_stats() -> proplists:proplist().
 get_stats() ->
     case riak_core_stat_cache:get_stats(?APP) of
-        {ok, Stats, _TS} ->
+        {ok, Stats} ->
             Stats;
         Error -> Error
     end.
@@ -91,7 +89,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Update the given `Stat'.
 -spec update1(term()) -> ok.
 update1(pbc_connect) ->
-    exometer_entry:update([?APP, pbc_connects], 1).
+    exometer:update([?APP, pbc_connects], 1).
 
 %% -------------------------------------------------------------------
 %% Private
@@ -103,27 +101,7 @@ stats() ->
       {function, ?MODULE, active_pb_connects}}
     ].
 
-%% stat_name(Name) when is_list(Name) ->
-%%     list_to_tuple([?APP] ++ Name);
-%% stat_name(Name) when is_atom(Name) ->
-%%     {?APP, Name}.
-stat_name(Name) ->
-    [?APP | stat_name_(Name)].
-
-stat_name_(Name) when is_tuple(Name) ->
-    tuple_to_list(Name);
-stat_name_(Name) when is_list(Name) ->
-    Name;
-stat_name_(Name) when is_atom(Name) ->
-    [Name].
-
-
-register_stat(Name, spiral) ->
-    exometer_entry:new(Name, spiral);
-register_stat(Name, {function, _Module, _Function}=Fun) ->
-    exometer_entry:new(Name, Fun).
-
-active_pb_connects() ->
+active_pb_connects(_) ->
     %% riak_api_pb_sup will not be running when there are no listeners
     %% defined.
     case erlang:whereis(riak_api_pb_sup) of

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -45,7 +45,7 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
-    [(catch folsom_metrics:delete_metric({?APP, Name})) || {Name, _Type} <- stats()],
+    [(catch exometer_entry:delete([?APP, Name])) || {Name, _Type} <- stats()],
     [register_stat(stat_name(Stat), Type) || {Stat, Type} <- stats()],
     riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
 
@@ -91,7 +91,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Update the given `Stat'.
 -spec update1(term()) -> ok.
 update1(pbc_connect) ->
-    folsom_metrics:notify_existing_metric({?APP, pbc_connects}, 1, spiral).
+    exometer_entry:update([?APP, pbc_connects], 1).
 
 %% -------------------------------------------------------------------
 %% Private
@@ -103,16 +103,25 @@ stats() ->
       {function, ?MODULE, active_pb_connects}}
     ].
 
-stat_name(Name) when is_list(Name) ->
-    list_to_tuple([?APP] ++ Name);
-stat_name(Name) when is_atom(Name) ->
-    {?APP, Name}.
+%% stat_name(Name) when is_list(Name) ->
+%%     list_to_tuple([?APP] ++ Name);
+%% stat_name(Name) when is_atom(Name) ->
+%%     {?APP, Name}.
+stat_name(Name) ->
+    [?APP | stat_name_(Name)].
+
+stat_name_(Name) when is_tuple(Name) ->
+    tuple_to_list(Name);
+stat_name_(Name) when is_list(Name) ->
+    Name;
+stat_name_(Name) when is_atom(Name) ->
+    [Name].
+
 
 register_stat(Name, spiral) ->
-    folsom_metrics:new_spiral(Name);
+    exometer_entry:new(Name, spiral);
 register_stat(Name, {function, _Module, _Function}=Fun) ->
-    folsom_metrics:new_gauge(Name),
-    folsom_metrics:notify({Name, Fun}).
+    exometer_entry:new(Name, Fun).
 
 active_pb_connects() ->
     %% riak_api_pb_sup will not be running when there are no listeners

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -28,7 +28,7 @@
          produce_stats/0,
          update/1,
          stats/0,
-         active_pb_connects/1]).
+         active_pb_connects/0, active_pb_connects/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -45,16 +45,36 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register_stats() ->
+    case riak_core_stat:stat_system() of
+        legacy   -> register_stats_legacy();
+        exometer -> register_stats_exometer()
+    end.
+
+register_stats_legacy() ->
+    [(catch folsom_metrics:delete_metric({?APP, Name})) || {Name, _Type} <- stats()],
+    [register_stat(stat_name(Stat), Type) || {Stat, Type} <- stats()],
+    riak_core_stat_cache:register_app(?APP, {?MODULE, produce_stats, []}).
+
+register_stats_exometer() ->
     riak_core_stat:register_stats(?APP, stats()).
 
 %% @doc Return current aggregation of all stats.
 -spec get_stats() -> proplists:proplist().
 get_stats() ->
+    case riak_core_stat:stat_system() of
+        legacy   -> get_stats_legacy();
+        exometer -> get_stats_exometer()
+    end.
+
+get_stats_legacy() ->
     case riak_core_stat_cache:get_stats(?APP) of
         {ok, Stats} ->
             Stats;
         Error -> Error
     end.
+
+get_stats_exometer() ->
+    riak_core_stat:get_stats(?APP).
 
 produce_stats() ->
     {?APP, riak_core_stat_q:get_stats([riak_api])}.
@@ -88,7 +108,16 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% @doc Update the given `Stat'.
 -spec update1(term()) -> ok.
-update1(pbc_connect) ->
+update1(Arg) ->
+    case riak_core_stat:stat_system() of
+        legacy   -> update1_legacy(Arg);
+        exometer -> update1_exometer(Arg)
+    end.
+
+update1_legacy(pbc_connect) ->
+    folsom_metrics:notify_existing_metric({?APP, pbc_connects}, 1, spiral).
+
+update1_exometer(pbc_connect) ->
     exometer:update([?APP, pbc_connects], 1).
 
 %% -------------------------------------------------------------------
@@ -101,6 +130,27 @@ stats() ->
       {function, ?MODULE, active_pb_connects}}
     ].
 
+stat_name(Name) when is_list(Name) ->
+    list_to_tuple([?APP] ++ Name);
+stat_name(Name) when is_atom(Name) ->
+    {?APP, Name}.
+
+register_stat(Name, spiral) ->
+    folsom_metrics:new_spiral(Name);
+register_stat(Name, {function, _Module, _Function}=Fun) ->
+    folsom_metrics:new_gauge(Name),
+    folsom_metrics:notify({Name, Fun}).
+
+%% called by legacy stats
+active_pb_connects() ->
+    %% riak_api_pb_sup will not be running when there are no listeners
+    %% defined.
+    case erlang:whereis(riak_api_pb_sup) of
+        undefined -> 0;
+        _ -> proplists:get_value(active, supervisor:count_children(riak_api_pb_sup))
+    end.
+
+%% called by exometer (Arg, DataPoints, ignored)
 active_pb_connects(_) ->
     %% riak_api_pb_sup will not be running when there are no listeners
     %% defined.


### PR DESCRIPTION
See [riak_core PR 487](https://github.com/basho/riak_core/pull/487):

The function identifying which system is used is riak_core_stat:stat_system(). This function is hard-coded to 'exometer', but can be changed to 'legacy' by setting the OS environment variable RIAK_CORE_STAT_SYSTEM to "legacy", and ensuring that the module riak_core_stat.erl is recompiled.
