### PR TITLE
Refactor riak_api_pb_service to use callback mod attributes

### DIFF
--- a/src/riak_api_pb_service.erl
+++ b/src/riak_api_pb_service.erl
@@ -158,9 +158,6 @@
 -module(riak_api_pb_service).
 -compile([{no_auto_import, [register/2]}]).
 
-%% Behaviour API
--export([behaviour_info/1]).
-
 %% Service-provider API
 -export([register/1,
          register/2,
@@ -174,16 +171,33 @@
 
 -export_type([registration/0]).
 
-%% @doc Behaviour information callback. PB API services must implement
-%% the given functions.
-behaviour_info(callbacks) ->
-    [{init,0},
-     {decode,2},
-     {encode,1},
-     {process,2},
-     {process_stream,3}];
-behaviour_info(_) ->
-    undefined.
+-callback init() -> State :: term().
+
+-type perm_and_target() :: {Permission :: string(), Target :: term()}.
+-callback decode(Code :: non_neg_integer(), Message :: binary()) ->
+    {ok, DecodedMessage :: term()} |
+    {ok, DecodedMessage :: term(), perm_and_target()} |
+    {error, Reason :: term()}.
+
+-callback encode(Message :: term()) ->
+    {ok, EncodedMessage :: iodata()} |
+    term().
+
+-type process_error() :: iodata() |
+                         {format, term()} |
+                         {format, io:format(), [term()]}.
+
+-callback process(Message :: term(), State :: term()) ->
+    {reply, ReplyMessage :: term(), NewState :: term()} |
+    {reply, {stream, ReqId :: term()}, NewState :: term()} |
+    {error, Error :: process_error(), NewState :: term()}.
+
+-callback process_stream(Message :: term(), ReqId :: term(), State :: term()) ->
+    {reply, Reply :: [term()] | term(), NewState :: term()} |
+    {ignore, NewState :: term()} |
+    {done, Reply :: [term()] | term(), NewState :: term()} |
+    {done, NewState :: term()} |
+    {error, Error :: process_error(), NewState :: term()}.
 
 %% @doc Registers a number of services at once.
 %% @see register/3

--- a/src/riak_api_pb_service.erl
+++ b/src/riak_api_pb_service.erl
@@ -63,19 +63,23 @@
 %% ```
 %% decode(Code, Message) ->
 %%     {ok, DecodedMessage} |
+%%     {ok, DecodedMessage, PermAndTarget} |
 %%     {error, Reason}.
 %%
 %%     Code = non_neg_integer()
 %%     Message = binary()
 %%     DecodedMessage = Reason = term()
+%%     PermAndTarget = {string(), term()}
 %% '''
 %%
 %% The `decode/2' callback is handed a message code and wire message
 %% that is registered to this service and should decode it into an
 %% Erlang term that can be handled by the `process/2' callback. If the
 %% message does not decode properly, it should return an `error' tuple
-%% with an appropriate reason. Most services will simply delegate
-%% encoding to the `riak_pb' application.
+%% with an appropriate reason. The decoded message may optionally
+%% include a permission and target tuple used by the security system
+%% to restrict access to the operation.  Most services will simply
+%% delegate encoding to the `riak_pb' application.
 %%
 %% ```
 %% encode(Message) ->

--- a/src/riak_api_pb_service.erl
+++ b/src/riak_api_pb_service.erl
@@ -69,7 +69,7 @@
 %%     Code = non_neg_integer()
 %%     Message = binary()
 %%     DecodedMessage = Reason = term()
-%%     PermAndTarget = {string(), term()}
+%%     PermAndTarget = perm_and_target()
 %% '''
 %%
 %% The `decode/2' callback is handed a message code and wire message


### PR DESCRIPTION
Use `-callback` module attributes instead of `behavior_info` to declare the callbacks. This plays better with dialyzer and will get rid of all the `Callback info about the riak_api_pb_service behaviour is not available` warnings across the projects.

Also updated the `decode` callback attribute and edoc to include the optional security namespace.

@Vagabond @seancribbs Might want to give a quick look around my "security namespace" addition. I'm not 100% that is the best name or if I documented it properly.
