### PR TITLE
HAproxy health-check causes node shutdown

### DIFF
--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -565,7 +565,7 @@ format_peername({IP, Port}) ->
 %%
 validate_function(Cert, valid_peer, State) ->
     lager:debug("validing peer ~p with ~p intermediate certs",
-                [riak_core_ssl_util:get_common_name(Cert), 
+                [riak_core_ssl_util:get_common_name(Cert),
                  length(element(2, State))]),
     %% peer certificate validated, now check the CRL
     Res = (catch check_crl(Cert, State)),
@@ -603,7 +603,7 @@ check_crl(Cert, State) ->
             no_crl;
         CRLExtension ->
             CRLDistPoints = CRLExtension#'Extension'.extnValue,
-            DPointsAndCRLs = lists:foldl(fun(Point, Acc) -> 
+            DPointsAndCRLs = lists:foldl(fun(Point, Acc) ->
                             %% try to read the CRL over http or from a
                             %% local file
                             case fetch_point(Point) of
@@ -611,11 +611,11 @@ check_crl(Cert, State) ->
                                     Acc;
                                 Res ->
                                     [{Point, Res} | Acc]
-                            end 
+                            end
                     end, [], CRLDistPoints),
-            public_key:pkix_crls_validate(Cert, 
-                                          DPointsAndCRLs, 
-                                          [{issuer_fun, 
+            public_key:pkix_crls_validate(Cert,
+                                          DPointsAndCRLs,
+                                          [{issuer_fun,
                                             {fun issuer_function/4, State}}])
     end.
 
@@ -635,13 +635,13 @@ issuer_function(_DP, CRL, _Issuer, {TrustedCAs, IntermediateCerts}) ->
     %% assume certificates are ordered from root to tip
     case find_issuer(Issuer, IntermediateCerts ++ Certs) of
         undefined ->
-            lager:debug("unable to find certificate matching CRL issuer ~p", 
+            lager:debug("unable to find certificate matching CRL issuer ~p",
                         [Issuer]),
             error;
         IssuerCert ->
-            case build_chain({public_key:pkix_encode('OTPCertificate', 
-                                                     IssuerCert, 
-                                                     otp), 
+            case build_chain({public_key:pkix_encode('OTPCertificate',
+                                                     IssuerCert,
+                                                     otp),
                               IssuerCert}, IntermediateCerts, Certs, []) of
                 undefined ->
                     error;
@@ -652,9 +652,9 @@ issuer_function(_DP, CRL, _Issuer, {TrustedCAs, IntermediateCerts}) ->
 
 %% @doc Attempt to build authority chain back using intermediary
 %%      certificates, falling back on trusted certificates if the
-%%      intermediary chain of certificates does not fully extend to the 
+%%      intermediary chain of certificates does not fully extend to the
 %%      root.
-%% 
+%%
 %%      Returns: {RootCA :: #OTPCertificate{}, Chain :: [der_encoded()]}
 %%
 build_chain({DER, Cert}, IntCerts, TrustedCerts, Acc) ->
@@ -672,7 +672,7 @@ build_chain({DER, Cert}, IntCerts, TrustedCerts, Acc) ->
                 TrustedCert ->
                     %% return the cert from the trusted list, to prevent
                     %% issuer spoofing
-                    {TrustedCert, 
+                    {TrustedCert,
                      [public_key:pkix_encode(
                                 'OTPCertificate', TrustedCert, otp)|Acc]}
             end;
@@ -730,8 +730,8 @@ find_issuer(Issuer, Certs) ->
 %% @doc Find distribution points for a given CRL and then attempt to
 %%      fetch the CRL from the first available.
 fetch_point(#'DistributionPoint'{distributionPoint={fullName, Names}}) ->
-    Decoded = [{NameType, 
-                pubkey_cert_records:transform(Name, decode)} 
+    Decoded = [{NameType,
+                pubkey_cert_records:transform(Name, decode)}
                || {NameType, Name} <- Names],
     fetch(Decoded).
 
@@ -754,7 +754,7 @@ fetch([{uniformResourceIdentifier, "http"++_=URL}|Rest]) ->
         {ok, {_Status, _Headers, Body}} ->
             case Body of
                 <<"-----BEGIN", _/binary>> ->
-                    [{'CertificateList', 
+                    [{'CertificateList',
                       DER, _}=CertList] = public_key:pem_decode(Body),
                     {DER, public_key:pem_entry_decode(CertList)};
                 _ ->
@@ -769,7 +769,7 @@ fetch([{uniformResourceIdentifier, "http"++_=URL}|Rest]) ->
     end;
 fetch([Loc|Rest]) ->
     %% unsupported CRL location
-    lager:debug("unable to fetch CRL from unsupported location ~p", 
+    lager:debug("unable to fetch CRL from unsupported location ~p",
                 [Loc]),
     fetch(Rest).
 

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -46,7 +46,7 @@
          terminate/3, code_change/4]).
 
 -record(state, {
-          transport = {gen_tcp, inet} :: {module(), module()},
+          transport = {gen_tcp, inet} :: {gen_tcp, inet} | {ssl, ssl},
           socket :: port() | ssl:sslsocket(),   % socket
           req,                % current request
           states :: orddict:orddict(),    % per-service connection state

--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -47,7 +47,7 @@
 
 -record(state, {
           transport = {gen_tcp, inet} :: {module(), module()},
-          socket :: port(),   % socket
+          socket :: port() | ssl:sslsocket(),   % socket
           req,                % current request
           states :: orddict:orddict(),    % per-service connection state
           peername :: undefined | {inet:ip_address(), pos_integer()},
@@ -82,7 +82,7 @@ service_registered(Pid, Mod) ->
 
 %% @doc The gen_server init/1 callback, initializes the
 %% riak_api_pb_server.
--spec init(list()) -> {ok, #state{}}.
+-spec init(list()) -> {ok, wait_for_socket, #state{}}.
 init([]) ->
     riak_api_stat:update(pbc_connect),
     ServiceStates = lists:foldl(fun(Service, States) ->
@@ -374,15 +374,14 @@ terminate(_Reason, _StateName, _State) ->
 
 %% @doc The gen_server code_change/3 callback, called when performing
 %% a hot code upgrade on the server. Currently unused.
--spec code_change(OldVsn, StateName, State, Extra) -> {ok, State} | {error, Reason} when
+-spec code_change(OldVsn, StateName, State, Extra) -> {ok, StateName, State} when
       OldVsn :: Vsn | {down, Vsn},
       Vsn :: term(),
       StateName :: atom(),
       State :: #state{},
-      Extra :: term(),
-      Reason :: term().
-code_change(_OldVsn, _StateName, State, _Extra) ->
-    {ok, State}.
+      Extra :: term().
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
 
 %% ===================================================================
 %% Internal functions


### PR DESCRIPTION
HAproxy uses a naïve health-check mechanism that simply opens a TCP socket and then closes it immediately after it is accepted by the server. This causes the call to `peername/1` in `riak_api_pb_server` to return `{error, enotconn}` instead of the expected `{ok, Peername}`. The resulting badmatch propagates to the listener process (it was waiting on a reply via `gen_fsm:sync_send_event`), which then crashes the application supervisor after too many restarts.

Using this example config:

```
listen riak_pbc_demo_10 0.0.0.0:9109
    balance leastconn
    option tcplog
    mode tcp
    server 127.0.0.1 127.0.0.1:8087 check
```
