### PR TITLE
No longer call deprecated function

### DIFF
--- a/priv/riak_api.schema
+++ b/priv/riak_api.schema
@@ -134,7 +134,7 @@
 {translation,
  "riak_api.tls_protocols",
  fun(Conf) ->
-    Protocols = cuttlefish_util:filter_by_variable_starts_with("tls_protocols", Conf),
+    Protocols = cuttlefish_variable:filter_by_prefix("tls_protocols", Conf),
     [begin
          case Key of
              ["tls_protocols","sslv3"] ->


### PR DESCRIPTION
This is a schema review that doesn't need PM or CSE because no client facing feature changed. just the implementation of a translation to not call a deprecated function.
