### PR TITLE
Change error message returned when no module reg.

### DIFF
--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -277,7 +277,12 @@ connected({msg, MsgCode, MsgData}, State=#state{states=ServiceStates}) ->
                         send_error("Message decoding error: ~p", [Reason], State)
                 end;
             error ->
-                send_error("Unknown message code.", State)
+                case riak_pb_codec:msg_code(rpbstarttls) of
+                    MsgCode ->
+                        send_error("Security not enabled; STARTTLS not allowed.", State);
+                    _ ->
+                        send_error("Unknown message code: ~p", [MsgCode], State)
+                end
         end,
         {next_state, connected, NewState}
     catch


### PR DESCRIPTION
When the client sends a starttls message and security is
not enabled Riak will now return a specific message indicating
that was the case. In addition, in other cases the code is
now returned as part of the error message.
