### PR TITLE
Do not treat errors as success

### DIFF
--- a/src/riak_api_ssl.erl
+++ b/src/riak_api_ssl.erl
@@ -87,8 +87,10 @@ validate_function(Cert, valid, {TrustedCAs, IntermediateCerts}=State) ->
                         [riak_core_ssl_util:get_common_name(Cert), Res]),
             {Res, {TrustedCAs, [Cert|IntermediateCerts]}}
     end;
-validate_function(_Cert, _Event, State) ->
-    {valid, State}.
+validate_function(_,{bad_cert, _} = Reason, _) ->
+    {fail, Reason};
+validate_function(_,{extension, _}, UserState) ->
+    {unknown, UserState}.
 
 %% @doc Given a certificate, find CRL distribution points for the given
 %%      certificate, fetch, and attempt to validate each CRL through

--- a/src/riak_api_ssl.erl
+++ b/src/riak_api_ssl.erl
@@ -87,9 +87,9 @@ validate_function(Cert, valid, {TrustedCAs, IntermediateCerts}=State) ->
                         [riak_core_ssl_util:get_common_name(Cert), Res]),
             {Res, {TrustedCAs, [Cert|IntermediateCerts]}}
     end;
-validate_function(_,{bad_cert, _} = Reason, _) ->
+validate_function(_Cert, {bad_cert, _} = Reason, _UserState) ->
     {fail, Reason};
-validate_function(_,{extension, _}, UserState) ->
+validate_function(_Cert, {extension, _}, UserState) ->
     {unknown, UserState}.
 
 %% @doc Given a certificate, find CRL distribution points for the given


### PR DESCRIPTION
As discussed in #65 (at least two problems tackled there, so this does not yet suffice to close the ticket) the function sent to the OTP SSL libraries for supplemental certificate validation should fail by default, not succeed.

I have not been able to generate certificates that demonstrate the undesirable behavior for automated testing, but certificates originally created by @bkerley revealed the problem and were used to test this fix.
