### PR TITLE
Absence of CRL is acceptable for certificate validation

### DIFF
--- a/src/riak_api_ssl.erl
+++ b/src/riak_api_ssl.erl
@@ -103,8 +103,8 @@ check_crl(Cert, State) ->
         undefined ->
             lager:debug("no CRL distribution points for ~p",
                          [riak_core_ssl_util:get_common_name(Cert)]),
-            %% fail; we can't validate if there's no CRL
-            no_crl;
+            %% CRLs are not mandatory
+            valid;
         CRLExtension ->
             CRLDistPoints = CRLExtension#'Extension'.extnValue,
             DPointsAndCRLs = lists:foldl(fun(Point, Acc) ->


### PR DESCRIPTION
In 2.0, we failed certificate verification if no certificate revocation list was present, but that's too aggressive. CRL is optional.

Finishes addressing #65.

Hope to have riak_test updates, but will take some time to disentangle the CRL pieces. This **has** addressed the server-side problems with @bkerley's JRuby tests.
