### PR TITLE
Remove afunix from EXOMETER_PACKAGES.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: deps
 
-EXOMETER_PACKAGES = "(basic), +afunix"
+EXOMETER_PACKAGES = "(basic)"
 export EXOMETER_PACKAGES
 
 all: compile


### PR DESCRIPTION
Afunix is not used at this time, and may cause build issues on some
platforms.
