### PR TITLE
Use exometer_core & exometer aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 .PHONY: deps
 
-EXOMETER_PACKAGES = "(basic)"
-export EXOMETER_PACKAGES
-
 all: compile
 
 deps:

--- a/src/riak_api_stat.erl
+++ b/src/riak_api_stat.erl
@@ -93,9 +93,9 @@ update1(pbc_connect) ->
 %% -------------------------------------------------------------------
 stats() ->
     [
-     {pbc_connects, spiral},
-     {[pbc_connects, active],
-      {function, ?MODULE, active_pb_connects}}
+     {pbc_connects, spiral, [], [{one, pbc_connects},
+                                 {count, pbc_connects_total}]},
+     {[pbc_connects, active], {function, ?MODULE, active_pb_connects}, [], [{value, pbc_active}]}
     ].
 
 active_pb_connects(_) ->


### PR DESCRIPTION
Addresses RIAK-1292 and RIAK-1295
- Exometer-specific settings removed from Makefile
- Stats entries and stats aliases registered together
