### PR TITLE
add interface for pb bucket key active preflist

### DIFF
--- a/src/riak_api_app.erl
+++ b/src/riak_api_app.erl
@@ -33,7 +33,8 @@
                    %% because it is started before riak_api.
                    {riak_core_pb_bucket, 19, 22},
                    {riak_core_pb_bucket, 29, 30},
-                   {riak_core_pb_bucket_type, 31, 33}
+                   {riak_core_pb_bucket_type, 31, 32},
+                   {riak_core_pb_bucket_key_apl, 33, 34}
                   ]).
 
 %% @doc The application:start callback.

--- a/src/riak_core_pb_bucket.erl
+++ b/src/riak_core_pb_bucket.erl
@@ -48,7 +48,9 @@
          decode/2,
          encode/1,
          process/2,
-         process_stream/3]).
+         process_stream/3,
+         maybe_create_bucket_type/2,
+         bucket_type/2]).
 
 -include_lib("riak_pb/include/riak_pb.hrl").
 

--- a/src/riak_core_pb_bucket_key_apl.erl
+++ b/src/riak_core_pb_bucket_key_apl.erl
@@ -1,0 +1,82 @@
+%% --------------------------------------------------------------------------
+%%
+%% riak_core_pb_bucket_key_apl: Expose Core active preflist functionality to
+%%                              Protocol Buffers
+%%
+%% Copyright (c) 2015 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% --------------------------------------------------------------------------
+
+%% @doc <p>The Bucket-Key Preflist (Primaries & Fallbacks) PB service
+%% for Riak Core. This service covers the following request messages in the
+%% original protocol:</p>
+%%
+%% <pre>
+%% 33 - RpbGetBucketKeyPreflistReq
+%% </pre>
+%%
+%% <p>This service produces the following responses:</p>
+%%
+%% <pre>
+%% 34 - RpbGetBucketKeyPreflistResp
+%% </pre>
+%%
+%% @end
+-module(riak_core_pb_bucket_key_apl).
+
+-behaviour(riak_api_pb_service).
+
+-export([init/0,
+         decode/2,
+         encode/1,
+         process/2,
+         process_stream/3]).
+
+-include_lib("riak_pb/include/riak_pb.hrl").
+
+init() ->
+    undefined.
+
+%% @doc decode/2 callback. Decodes an incoming message.
+decode(Code, Bin) when Code == 33 ->
+    Msg =  riak_pb_codec:decode(Code, Bin),
+    case Msg of
+        #rpbgetbucketkeypreflistreq{type =T, bucket =B, key =Key} ->
+            Bucket = riak_core_pb_bucket:bucket_type(T, B),
+            {ok, Msg, {"riak_core.get_preflist", {Bucket, Key}}}
+    end.
+
+%% @doc encode/1 callback. Encodes an outgoing response message.
+encode(Message) ->
+    {ok, riak_pb_codec:encode(Message)}.
+
+%% Get bucket-key preflist primaries
+process(#rpbgetbucketkeypreflistreq{type=T, bucket=B0, key =K}, State) ->
+    B = riak_core_pb_bucket:maybe_create_bucket_type(T, B0),
+    Preflist = riak_core_apl:get_apl_ann_with_pnum({B, K}),
+    case Preflist of
+        [] ->
+            {error, {format,
+                     "No preflist for bucket '~s' and key '~s'",
+                     [B, K]}, State};
+        P ->
+            PbPreflist = riak_pb_codec:encode_apl_ann(P),
+            {reply, #rpbgetbucketkeypreflistresp{preflist=PbPreflist}, State}
+    end.
+
+process_stream(_, _, State) ->
+    {ignore, State}.


### PR DESCRIPTION
**Note:** **Bors will fail** on this until a new version is referenced in rebar.config incorporating the update in https://github.com/basho/riak_pb/pull/105 and the [`riak_core` update](https://github.com/basho/riak_core/pull/705) is reviewed/merged.
### Description

Part of [RIAK-1481](https://bashoeng.atlassian.net/browse/RIAK-1481).

The active preflist will return primary/fallback partitions and nodes for the available nodes at the time of query. Primary/fallback will be annotated.
This involves updates to our RiakKV WB code, RiakPB, RiakCore, RiakAPI, Riak-Erlang-Http-Client, Riak-Erlang-Client.

*The impetus for adding this to the API started with a mailing list question answered by Charlie Voiselle, http://lists.basho.com/pipermail/riak-users_lists.basho.com/2015-January/016527.html, which involved a snippet of code that we've given clients multiple times. This was then discussed with Russell Brown on HipChat, https://basho.hipchat.com/history/room/867200/2015/01/13?q=enterprising&t=rid-867200#12:23:22.

Other PRs in the series:
- https://github.com/basho/riak_core/pull/705
- https://github.com/basho/riak_pb/pull/105
- https://github.com/basho/riak_kv/pull/1083
- https://github.com/basho/riak-erlang-http-client/pull/50
- https://github.com/basho/riak-erlang-client/pull/204
