### PR TITLE
Update rebar versions for riak_pb and riak_core

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,9 +2,9 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_pb, "2.0.0.17", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.17"}}},
+        {riak_pb, "2.0.0.18", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.18"}}},
         {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8"}}},
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop"}}}
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "2.0.5"}}}
         ]}.
 
 {xref_checks, [undefined_function_calls]}.


### PR DESCRIPTION
`riak_pb` is now 2.0.0.18 and `riak_core` is 2.0.5
