### PR TITLE
Bump rebar.config dependency on riak_core to 2.1.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [
         {riak_pb, "2.1.0.0", {git, "git://github.com/basho/riak_pb.git", {tag, "2.1.0.0"}}},
         {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8"}}},
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "2.0.5"}}}
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "2.1.0"}}}
         ]}.
 
 {xref_checks, [undefined_function_calls]}.


### PR DESCRIPTION
Since the 2.0.5 tag had some post-2.0 features we need to bump the version
