### PR TITLE
Updated riab_pb dependency to 2.1.0.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_pb, "2.1.0.1", {git, "git://github.com/basho/riak_pb.git", {tag, "2.1.0.1"}}},
+        {riak_pb, "2.1.0.2", {git, "git://github.com/basho/riak_pb.git", {tag, "2.1.0.2"}}},
         {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "2.1.0"}}}
         ]}.


### PR DESCRIPTION
Pointing to riak_pb 2.1.0.2
