### PR TITLE
Set riak_core dependency to 2.1.1 tag

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [
         {riak_pb, "2.1.0.2", {git, "git://github.com/basho/riak_pb.git", {tag, "2.1.0.2"}}},
         {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8"}}},
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "2.1.0"}}}
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "2.1.1"}}}
         ]}.
 
 {xref_checks, [undefined_function_calls]}.


### PR DESCRIPTION
I had to update the dependency on riak_core, in order to pick up the latest changes to eleveldb
