### PR TITLE
[pb_listener] Add TCP keepalive feature

### DIFF
--- a/priv/riak_api.schema
+++ b/priv/riak_api.schema
@@ -57,6 +57,14 @@
   hidden
 ]}.
 
+%% @doc Turns on TCP keepalive for Protocol Buffers connections.
+%% This is equivalent to setting the SO_KEEPALIVE option on the socket.
+{mapping, "protobuf.keepalive", "riak_api.pb_keepalive", [
+  {datatype, flag},
+  {default, on},
+  hidden
+]}.
+
 %% @doc listener.https.<name> is an IP address and TCP port that the Riak
 %% HTTPS interface will bind.
 {mapping, "listener.https.$name", "riak_api.https", [

--- a/src/riak_api_pb_listener.erl
+++ b/src/riak_api_pb_listener.erl
@@ -46,7 +46,7 @@ init([PortNum]) ->
 sock_opts() ->
     BackLog = app_helper:get_env(riak_api, pb_backlog, 128),
     NoDelay = app_helper:get_env(riak_api, disable_pb_nagle, true),
-    [binary, {packet, raw}, {reuseaddr, true}, {backlog, BackLog}, {nodelay, NoDelay}].
+    [binary, {packet, raw}, {reuseaddr, true}, {backlog, BackLog}, {nodelay, NoDelay}, {keepalive, true}].
 
 %% @doc The handle_call/3 gen_nb_server callback. Unused.
 -spec handle_call(term(), {pid(),_}, #state{}) -> {reply, term(), #state{}}.

--- a/src/riak_api_pb_listener.erl
+++ b/src/riak_api_pb_listener.erl
@@ -46,7 +46,8 @@ init([PortNum]) ->
 sock_opts() ->
     BackLog = app_helper:get_env(riak_api, pb_backlog, 128),
     NoDelay = app_helper:get_env(riak_api, disable_pb_nagle, true),
-    [binary, {packet, raw}, {reuseaddr, true}, {backlog, BackLog}, {nodelay, NoDelay}, {keepalive, true}].
+    KeepAlive = app_helper:get_env(riak_api, pb_keepalive, true),
+    [binary, {packet, raw}, {reuseaddr, true}, {backlog, BackLog}, {nodelay, NoDelay}, {keepalive, KeepAlive}].
 
 %% @doc The handle_call/3 gen_nb_server callback. Unused.
 -spec handle_call(term(), {pid(),_}, #state{}) -> {reply, term(), #state{}}.

--- a/test/riak_api_schema_tests.erl
+++ b/test/riak_api_schema_tests.erl
@@ -12,6 +12,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_not_configured(Config, "riak_api.https"),
     cuttlefish_unit:assert_config(Config, "riak_api.pb_backlog", 128),
     cuttlefish_unit:assert_config(Config, "riak_api.disable_pb_nagle", true),
+    cuttlefish_unit:assert_config(Config, "riak_api.pb_keepalive", true),
     cuttlefish_unit:assert_config(Config, "riak_api.honor_cipher_order", basho_vm(true, false)),
     cuttlefish_unit:assert_config(Config, "riak_api.tls_protocols", ['tlsv1.2']),
     cuttlefish_unit:assert_config(Config, "riak_api.check_crl", basho_vm(true, false)),
@@ -29,6 +30,7 @@ override_schema_test() ->
         {["listener", "https", "external"], "127.0.0.13:443"},
         {["protobuf", "backlog"], 64},
         {["protobuf", "nagle"], on},
+        {["protobuf", "keepalive"], off},
         {["honor_cipher_order"], off},
         {["tls_protocols", "sslv3"], on},
         {["tls_protocols", "tlsv1"], on},
@@ -44,6 +46,7 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_api.https", [{"127.0.0.13", 443}, {"127.0.0.12", 443}]),
     cuttlefish_unit:assert_config(Config, "riak_api.pb_backlog", 64),
     cuttlefish_unit:assert_config(Config, "riak_api.disable_pb_nagle", false),
+    cuttlefish_unit:assert_config(Config, "riak_api.pb_keepalive", false),
     cuttlefish_unit:assert_config(Config, "riak_api.tls_protocols", ['tlsv1.1', tlsv1, sslv3]),
     cuttlefish_unit:assert_config(Config, "riak_api.check_crl", false),
     ok.


### PR DESCRIPTION
Without keepalive the pb_listener hangs on to established
connections in case of a network partition. This can lead
to available sockets being exhausted on servers with a high
number of concurrent connections.

Fixes #88 
