### PR TITLE
[pb_listener 1.4] enable TCP keepalive

### DIFF
--- a/src/riak_api_pb_listener.erl
+++ b/src/riak_api_pb_listener.erl
@@ -46,7 +46,8 @@ init([PortNum]) ->
 sock_opts() ->
     BackLog = app_helper:get_env(riak_api, pb_backlog, 5),
     NoDelay = app_helper:get_env(riak_api, disable_pb_nagle, false),
-    [binary, {packet, raw}, {reuseaddr, true}, {backlog, BackLog}, {nodelay, NoDelay}].
+    KeepAlive = app_helper:get_env(riak_api, pb_keepalive, true),
+    [binary, {packet, raw}, {reuseaddr, true}, {backlog, BackLog}, {nodelay, NoDelay}, {keepalive, KeepAlive}].
 
 %% @doc The handle_call/3 gen_nb_server callback. Unused.
 -spec handle_call(term(), pid(), #state{}) -> {reply, term(), #state{}}.


### PR DESCRIPTION
Without keepalive the pb_listener hangs on to established
connections in case of a network partition. This can lead
to available sockets being exhausted on servers with a high
number of concurrent connections.

Backport of https://github.com/basho/riak_api/pull/89
Fixes https://github.com/basho/riak_api/issues/88 for 1.4.x
