### PR TITLE
Add Bucket types API 

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_pb, "2.1.0.2", {git, "git://github.com/basho/riak_pb.git", {tag, "2.1.0.2"}}},
+        {riak_pb, "2.1.0.2", {git, "git://github.com/lixen/riak_pb.git", {branch, "bucket_types"}}},
         {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "2.1.1"}}}
         ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_pb, "2.1.0.2", {git, "git://github.com/lixen/riak_pb.git", {branch, "bucket_types"}}},
+        {riak_pb, "2.1.0.2", {git, "git://github.com/basho/riak_pb.git", {tag, "2.1.0.2"}}},
         {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "2.1.1"}}}
         ]}.

--- a/src/riak_api_app.erl
+++ b/src/riak_api_app.erl
@@ -34,7 +34,7 @@
                    {riak_core_pb_bucket, 19, 22},
                    {riak_core_pb_bucket, 29, 30},
                    {riak_core_pb_bucket_type, 31, 32},
-                   {riak_core_pb_bucket_type, 35, 39}
+                   {riak_core_pb_bucket_type, 35, 38}
                   ]).
 
 %% @doc The application:start callback.

--- a/src/riak_api_app.erl
+++ b/src/riak_api_app.erl
@@ -33,7 +33,8 @@
                    %% because it is started before riak_api.
                    {riak_core_pb_bucket, 19, 22},
                    {riak_core_pb_bucket, 29, 30},
-                   {riak_core_pb_bucket_type, 31, 32}
+                   {riak_core_pb_bucket_type, 31, 32},
+                   {riak_core_pb_bucket_type, 35, 39}
                   ]).
 
 %% @doc The application:start callback.

--- a/src/riak_core_pb_bucket_type.erl
+++ b/src/riak_core_pb_bucket_type.erl
@@ -56,7 +56,7 @@ decode(Code, Bin) ->
         #rpbcreatebuckettypereq{type=T} ->
             {ok, Msg, {"riak_core.create_bucket_type", T}};
         #rpbactivatebuckettypereq{type=T} ->
-            {ok, Msg, {"riak_core.create_bucket_type", T}}
+            {ok, Msg, {"riak_core.activate_bucket_type", T}}
     end.
 
 %% @doc encode/1 callback. Encodes an outgoing response message.

--- a/src/riak_core_pb_bucket_type.erl
+++ b/src/riak_core_pb_bucket_type.erl
@@ -68,7 +68,7 @@ process(#rpbcreatebuckettypereq{type = T, props = PbProps}, State) ->
     Props = riak_pb_codec:decode_bucket_props(PbProps),
     case riak_core_bucket_type:create(T, Props) of
         ok ->
-            {reply, rpbsetbucketresp, State};
+            {reply, rpbcreatebuckettyperesp, State};
         {error, Details} ->
             {error, {format, "Invalid bucket properties: ~p", [Details]}, State}
     end;
@@ -77,7 +77,7 @@ process(#rpbcreatebuckettypereq{type = T, props = PbProps}, State) ->
 process(#rpbactivatebuckettypereq{type = T}, State) ->
     case riak_core_bucket_type:activate(T) of
         ok ->
-            {reply, rpbsetbucketresp, State};
+            {reply, rpbactivatebuckettyperesp, State};
         {error, Details} ->
             {error, {format, "Invalid bucket type: ~p", [Details]}, State}
     end;


### PR DESCRIPTION
Add support for create and activate bucket types with riak-erlang-client
riakc_pb_socket:create_bucket_type(Pid, BucketType, BucketProps)
riakc_pb_socket:activate_bucket_type(Pid, BucketType)

basho/riak_kv#1123 (RIAK-1829)

Tested with:
https://github.com/basho/riak_pb/pull/115
https://github.com/basho/riak-erlang-client/pull/215
