### PR TITLE
Update dependencies for develop branch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps, [
         {riak_pb, "2.1.0.2", {git, "git://github.com/basho/riak_pb.git", {tag, "2.1.0.2"}}},
         {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8"}}},
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "2.1.1"}}}
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {tag, "develop"}}}
         ]}.
 
 {xref_checks, [undefined_function_calls]}.


### PR DESCRIPTION
The dependency on riak_core was set to `{tag, "2.1.1"}`, which was
causing version conflicts, so update to `{branch, "develop"}` instead.
