### PR TITLE
Bump webmachine to version 1.10.6-basho1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {eunit_opts, [verbose]}.
 {deps, [
         {riak_pb, "2.0.0.17", {git, "git://github.com/basho/riak_pb.git", {tag, "2.0.0.17"}}},
-        {webmachine, "1.10.6", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.6"}}},
+        {webmachine, "1.10.6-basho1", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.6-basho1"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "2.0"}}}
         ]}.
 


### PR DESCRIPTION
This incorporates a patched version of mochiweb that includes a bug fix
for the spurious 400 errors we've been seeing.
