### PR TITLE
Bump webmachine to 1.10.8-basho1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {eunit_opts, [verbose]}.
 {deps, [
         {riak_pb, "2.1.0.2", {git, "git://github.com/basho/riak_pb.git", {tag, "2.1.0.2"}}},
-        {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8"}}},
+        {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8-basho1"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-2.2"}}}
         ]}.
 


### PR DESCRIPTION
This pulls in our fix for the spurious 400 error mochiweb bug.
