### PR TITLE
READY: Perf/query ttb encoding

### DIFF
--- a/src/riak_api_pb_server.erl
+++ b/src/riak_api_pb_server.erl
@@ -61,10 +61,6 @@
 -type format() :: {format, term()} | {format, io:format(), [term()]}.
 -export_type([format/0]).
 
-%% Protobuf message code for switching between protobuf and native
-%% Erlang encoding.
--define(PB_TOGGLE_ENCODING, 110).
-
 %% ===================================================================
 %% Public API
 %% ===================================================================
@@ -213,32 +209,6 @@ connected(timeout, State=#state{outbuffer=Buffer}) ->
     %% Flush any protocol messages that have been buffering
     {ok, Data, NewBuffer} = riak_api_pb_frame:flush(Buffer),
     {next_state, connected, flush(Data, State#state{outbuffer=NewBuffer})};
-connected({msg, ?PB_TOGGLE_ENCODING, MsgData}, State) ->
-    %% Hard-coded match on the new native term_to_binary encoding message
-    try
-        #rpbtoggleencodingreq{use_native=Raw} = riak_pb_codec:decode(110, MsgData),
-        %% Generate a response in the same encoding before setting the
-        %% process dictionary flag
-        Resp = riak_pb_codec:encode(#rpbtoggleencodingresp{use_native=Raw}),
-
-        %% Future developers, please forgive me. Threading this all the
-        %% way through to the PB encoding layer would be a significant
-        %% change
-        put(pb_use_native_encoding, Raw),
-
-        %% Must send a response immediately despite buffering, so
-        %% force the issue
-        State1 = send_message(Resp, State),
-        {ok, Data, NewBuffer} = riak_api_pb_frame:flush(State1#state.outbuffer),
-        State2 = flush(Data, State1#state{outbuffer=NewBuffer}),
-        {next_state, connected, State2}
-    catch
-        Type:Failure ->
-            Trace = erlang:get_stacktrace(),
-            FState = send_error_and_flush({format, "Error processing incoming message: ~p:~p:~p",
-                                           [Type, Failure, Trace]}, State),
-            {stop, {Type, Failure, Trace}, FState}
-    end;
 connected({msg, MsgCode, MsgData}, State=#state{states=ServiceStates}) ->
     try
         %% First find the appropriate service module to dispatch


### PR DESCRIPTION
<hr>

**Context**

This is part of a set of related PRs to rework handling of PB vs TTB encoding for client/server messages:
- https://github.com/basho/riak-erlang-client/pull/267 
- https://github.com/basho/riak_pb/pull/182
- https://github.com/basho/riak_api/pull/109
- https://github.com/basho/riak_kv/pull/1378

The original addition of alternate encodings was a hybrid implementation which 1) required the client and server to agree via a handshaking protocol about what encoding would be used, 2) used messages for both encodings that were generated from the .proto files, but some were only used for TTB encoding, and 3) allowed the server to send PB-encoded responses to TTB-encoded requests.

This work is an attempt to rationalize this situation, and to simplify how differently-encoded messages are handled within riak.  The guiding principles are:
1. Even as we optimize encodings for RiakTS performance, the server should continue to support PB-encoding as before.  We do _not_, for example,  want to break custom PB connections made outside our supported client codebase
2. We should be able to optimize messages for whatever encoding is imposed on them.  
3. The server should handle interleaved messages with different encodings seamlessly, without any handshaking about encoding type
4. We should guarantee that responses are encoded in the same way as the requests that generated them

<hr>

**Notes**
- Regarding point 2. above, although we currently pack data into the same containers differently for PB vs TTB encoding, we do not currently have a use-case that requires separate message _structures_, so the decision was made to keep the existing .proto-generated messages until we have such a use-case.
- Because TTB encoding is self-describing, we do not need to switch on per-message 8-bit MsgCode, as with PB-encoded messages, to know how to decode them.  This work therefor adds a single new MsgCode (104) to indicate that a message is TTB-encoded.   This allows the server to determine what encoding is being used per-message and without handshaking, addressing point 3. above.  It also preserves the remaining 8-bit space for future messages if needed.
- The server now implements separate services for PB and TTB-encoded messages, selected on MsgCode.  Because the processing is done per-service, and not per-message, this also guarantees that responses are encoded in the same way as the requests, addressing point 4 above.  This is important, for example, for tsquery requests, where it is the encoding of the _responses_, not the _requests_ that matters for performance.

<hr>

**Changes in this repo:**

This change removes the need to synchronize encoding schemes between client and server that was accomplished by sending the PB_TOGGLE_ENCODING message.  Changes to riak_api_pb_server.erl simply remove all code that deals with the now-obsolete handshaking.
