### PR TITLE
Lock riak_pb to tag 2.1.4.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "riak_ts-develop"}}},
+        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {tag, "2.1.4.0"}}},
         {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "riak_ts-develop"}}}
         ]}.


### PR DESCRIPTION
Now that TS has been merged into `riak_pb`, just use the latest tag instead of a non-existent development branch.
