### PR TITLE
Move riak_pb up to the develop-2.2 branch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_pb, "2.1.0.2", {git, "git://github.com/basho/riak_pb.git", {tag, "2.1.0.2"}}},
+        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.2"}}},
         {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8-basho1"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-2.2"}}}
         ]}.


### PR DESCRIPTION
This pulls in work for HLL (and also helps us escape our endless hell of tag-bumping).
