### PR TITLE
[RTS-1707, RTS-1709] Added CORS support to riak_kv, filtering required for listener.$scheme

### DIFF
--- a/priv/riak_api.schema
+++ b/priv/riak_api.schema
@@ -86,7 +86,7 @@
                        (_) -> true
                    end,
       HTTPS = cuttlefish_variable:filter_by_prefix("listener.https", Conf),
-      [ IP || {Key, IP} <- HTTP, NotCorsKey(Key) ]
+      [ IP || {Key, IP} <- HTTPS, NotCorsKey(Key) ]
  end
 }.
 

--- a/priv/riak_api.schema
+++ b/priv/riak_api.schema
@@ -11,8 +11,14 @@
 {translation,
  "riak_api.http",
   fun(Conf) ->
+      %% riak_kv cors support uses a key that extends the key used here,
+      %% which is listener.$scheme.$name , so the cors keys should be filtered
+      %% out.
+      NotCorsKey = fun (["listener", Scheme, "cors_allowable_origin"|_T]) -> false;
+                       (_) -> true
+                   end,
       HTTP = cuttlefish_variable:filter_by_prefix("listener.http", Conf),
-      [ IP || {_, IP} <- HTTP]
+      [ IP || {Key, IP} <- HTTP, NotCorsKey(Key) ]
   end
 }.
 
@@ -76,8 +82,11 @@
 {translation,
  "riak_api.https",
  fun(Conf) ->
-     HTTPS = cuttlefish_variable:filter_by_prefix("listener.https", Conf),
-     [ IP || {_, IP} <- HTTPS]
+      NotCorsKey = fun (["listener", Scheme, "cors_allowable_origin"|_T]) -> false;
+                       (_) -> true
+                   end,
+      HTTPS = cuttlefish_variable:filter_by_prefix("listener.https", Conf),
+      [ IP || {Key, IP} <- HTTP, NotCorsKey(Key) ]
  end
 }.
 


### PR DESCRIPTION
supports:
* https://github.com/basho/riak_kv/pull/1607

* added filtering out of cors keys from riak_api.http and ...https, required due to improved UX of having CORS configured under the listener space.