### PR TITLE
Develop 2.9

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,8 +3,8 @@
 {eunit_opts, [verbose]}.
 {deps, [
         {riak_pb, "2.2.*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.2.5"}}},
-        {webmachine, "1.11.*", {git, "git://github.com/webmachine/webmachine.git", {tag, "1.11.1"}}},
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-2.9"}}}
+        {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8-basho1"}}},
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-2.2.5"}}}
         ]}.
 
 {xref_checks, [undefined_function_calls]}.

--- a/rebar.config
+++ b/rebar.config
@@ -3,8 +3,8 @@
 {eunit_opts, [verbose]}.
 {deps, [
         {riak_pb, "2.2.*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.2.5"}}},
-        {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8-basho1"}}},
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-2.2.5"}}}
+        {webmachine, ".*", {git, "git://github.com/martinsumner/webmachine.git", {branch, "develop-2.9"}}},
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-2.9"}}}
         ]}.
 
 {xref_checks, [undefined_function_calls]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,8 +2,8 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_pb, ".*", {git, "git://github.com/martinsumner/riak_pb.git", {branch, "develop-2.9"}}},
-        {webmachine, ".*", {git, "git://github.com/martinsumner/webmachine.git", {branch, "develop-2.9"}}},
+        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.9"}}},
+        {webmachine, ".*", {git, "git://github.com/basho/webmachine.git", {branch, "develop-2.9"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-2.9"}}}
         ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_pb, "2.2.*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.2.5"}}},
+        {riak_pb, ".*", {git, "git://github.com/martinsumner/riak_pb.git", {branch, "develop-2.9"}}},
         {webmachine, ".*", {git, "git://github.com/martinsumner/webmachine.git", {branch, "develop-2.9"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-2.9"}}}
         ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -3,8 +3,8 @@
 {eunit_opts, [verbose]}.
 {deps, [
         {riak_pb, "2.2.*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.2.5"}}},
-        {webmachine, "1.10.8", {git, "git://github.com/basho/webmachine.git", {tag, "1.10.8-basho1"}}},
-        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-2.2.5"}}}
+        {webmachine, "1.11.*", {git, "git://github.com/webmachine/webmachine.git", {tag, "1.11.1"}}},
+        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-2.9"}}}
         ]}.
 
 {xref_checks, [undefined_function_calls]}.


### PR DESCRIPTION
To resolve https://github.com/basho/riak_api/issues/123

Requires updates to develop-2.9 webmachine and mochiweb.

Also rolls back in riak_pb changes missing from RC1.