### PR TITLE
Mas 3.0 setrecbuf

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
         {webmachine, ".*", {git, "git://github.com/webmachine/webmachine.git", {branch, "master"}}},
         {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "develop-3.0"}}},
         %% TODO we need to override this for OTP 20 support until webmachine revs their dep
-        {mochiweb, ".*", {git, "git://github.com/mochi/mochiweb.git", {tag, "v2.17.0"}}}
+        {mochiweb, ".*", {git, "git://github.com/martinsumner/mochiweb.git", {branch, "mas-431response"}}}
         ]}.
 
 {profiles, [

--- a/src/riak_api.app.src
+++ b/src/riak_api.app.src
@@ -8,7 +8,8 @@
                   kernel,
                   stdlib,
                   lager,
-                  riak_core
+                  riak_core,
+                  gen_fsm_compat
                  ]},
   {registered, [riak_api_sup,
                 riak_api_pb_sup]},

--- a/src/riak_api_web.erl
+++ b/src/riak_api_web.erl
@@ -54,20 +54,31 @@ binding_config(Scheme, Binding) ->
      permanent, 5000, worker, [mochiweb_socket_server]}.
 
 spec_from_binding(http, Name, {Ip, Port}) ->
-    lists:flatten([{name, Name},
-                   {ip, Ip},
-                   {port, Port},
-                   {nodelay, true}],
-                  common_config());
-
+    Options = 
+        lists:flatten([{name, Name},
+                    {ip, Ip},
+                    {port, Port},
+                    {nodelay, true}],
+                    common_config()),
+    add_recbuf(Options);
 spec_from_binding(https, Name, {Ip, Port}) ->
-    lists:flatten([{name, Name},
-                   {ip, Ip},
-                   {port, Port},
-                   {ssl, true},
-                   {ssl_opts, riak_api_ssl:options()},
-                   {nodelay, true}],
-                  common_config()).
+    Options = 
+        lists:flatten([{name, Name},
+                    {ip, Ip},
+                    {port, Port},
+                    {ssl, true},
+                    {ssl_opts, riak_api_ssl:options()},
+                    {nodelay, true}],
+                    common_config()),
+    add_recbuf(Options).
+
+add_recbuf(Options) ->
+    case application:get_env(webmachine, recbuf) of
+        {ok, RecBuf} ->
+            [{recbuf, RecBuf}|Options];
+        _ ->
+            Options
+    end.
 
 spec_name(Scheme, Ip, Port) ->
     FormattedIP = if is_tuple(Ip); tuple_size(Ip) == 4 ->


### PR DESCRIPTION
Allow setting of receive buffer using same advanced.config as 2.9

Resolves dialyzer issue with missing gen_fsm_compact in app

Points to branch/fork of mochiweb to allow for return of "431" response code if the headers exceed the receive buffer (rather than a 400 Bad Request which gives the operator no clue as to what happened)