### PR TITLE
Now using OTP20 for check_crl and honor_cipher_order

### DIFF
--- a/priv/riak_api.schema
+++ b/priv/riak_api.schema
@@ -86,24 +86,17 @@
 %% dictates which cipher is chosen.
 {mapping, "honor_cipher_order", "riak_api.honor_cipher_order", [
   {datatype, {enum, [on, off]}},
-  {default, on},
+  {default, off},
   hidden
 ]}.
 
 {translation,
   "riak_api.honor_cipher_order",
    fun(Conf) ->
-     OTPVer = erlang:system_info(otp_release),
      CipherOrder = cuttlefish:conf_get("honor_cipher_order", Conf),
-     %% This is only available, as of December 2013, in basho patched R16B02,
-     %% so disable it if the VM is not patched by basho. This can be revised
-     %% for R17, when this patch is expected to be present mainline.
-     %% The basho patched OTP can be found at:
-     %% https://github.com/basho/otp/tree/OTP_R16B02_basho3
-     case {CipherOrder, string:str(OTPVer, "basho")} of
-       {_, 0} -> false;
-       {on, _} -> true;
-       {off, _} -> false
+     case CipherOrder of
+       on  -> true;
+       off -> false
      end
    end
 }.
@@ -177,22 +170,3 @@
         end
     end
 }.
-
-
-%%{translation,
-%% "riak_api.check_crl",
-%% fun(Conf) ->
-%%     OTPVer = erlang:system_info(otp_release),
-%%     CheckCRL = cuttlefish:conf_get("check_crl", Conf),
-%%     %% CRL checking is broken in mainline OTP as of R16B02, so Riak will ship
-%%     %% with a patched SSL/public_key to fix it. This means that we don't want
-%%     %% to pass this option to a vanilla OTP.
-%%     %% The basho patched OTP can be found at:
-%%     %% https://github.com/basho/otp/tree/OTP_R16B02_basho3
-%%     case {CheckCRL, string:str(OTPVer, "basho")} of
-%%       {_, 0} -> false;
-%%       {on, _} -> true;
-%%       {off, _} -> false
-%%     end
-%% end
-%%}.

--- a/test/riak_api_schema_tests.erl
+++ b/test/riak_api_schema_tests.erl
@@ -13,9 +13,9 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "riak_api.pb_backlog", 128),
     cuttlefish_unit:assert_config(Config, "riak_api.disable_pb_nagle", true),
     cuttlefish_unit:assert_config(Config, "riak_api.pb_keepalive", true),
-    cuttlefish_unit:assert_config(Config, "riak_api.honor_cipher_order", basho_vm(true, false)),
+    cuttlefish_unit:assert_config(Config, "riak_api.honor_cipher_order", false),
     cuttlefish_unit:assert_config(Config, "riak_api.tls_protocols", ['tlsv1.2']),
-    cuttlefish_unit:assert_config(Config, "riak_api.check_crl", basho_vm(true, false)),
+    cuttlefish_unit:assert_config(Config, "riak_api.check_crl", true),
     ok.
 
 override_schema_test() ->
@@ -64,10 +64,3 @@ context() ->
         {pb_ip, "127.0.0.1"},
         {pb_port, 8087}
     ].
-
-basho_vm(ExpectedIfBasho, ExpectedIfNot) ->
-    OTPVer = erlang:system_info(otp_release),
-    case string:str(OTPVer, "basho") of
-        0 -> ExpectedIfNot;
-        _ -> ExpectedIfBasho
-    end.


### PR DESCRIPTION
We can remove old checks for Basho VM